### PR TITLE
Use const instead of var

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,17 +8,17 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose 
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
 
-var browserify = require('browserify');
-var gulp = require('gulp');
-var source = require('vinyl-source-stream');
-var buffer = require('vinyl-buffer');
-var uglify = require('gulp-uglify');
-var gutil = require('gulp-util');
-var babelify = require('babelify');
+const browserify = require('browserify');
+const gulp = require('gulp');
+const source = require('vinyl-source-stream');
+const buffer = require('vinyl-buffer');
+const uglify = require('gulp-uglify');
+const gutil = require('gulp-util');
+const babelify = require('babelify');
 
 gulp.task('build', function () {
   // set up the browserify instance on a task basis
-  var b = browserify({
+  const b = browserify({
     entries: './index.js',
     debug: true,
     transform: [babelify.configure({

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose 
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
 
-var Zilliqa = require('./lib/zilliqa')
+const Zilliqa = require('./lib/zilliqa')
 
 if (typeof window !== 'undefined' && typeof window.Zilliqa === 'undefined') {
   window.Zilliqa = Zilliqa

--- a/lib/node.js
+++ b/lib/node.js
@@ -8,13 +8,12 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose 
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
 
-var util = require('./util')
-var validateArgs = util.validateArgs
-var request = require('request')
-var fetch = require('node-fetch')
+const fetch = require('node-fetch')
+const util = require('./util')
+const request = require('request')
+const validateArgs = util.validateArgs
 
-
-function Node (args) {
+function Node(args) {
   validateArgs(args, {
     url: [util.isUrl]
   })

--- a/lib/zilliqa.js
+++ b/lib/zilliqa.js
@@ -8,11 +8,12 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose 
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
 
-var Node = require('./node')
-var util = require('./util')
-var schnorr = require('./schnorr')
-var config = require('./config.json')
-var validateArgs = util.validateArgs
+const Node = require('./node')
+const util = require('./util')
+const schnorr = require('./schnorr')
+const config = require('./config.json')
+
+const validateArgs = util.validateArgs
 
 
 function Zilliqa (args) {


### PR DESCRIPTION
Let's use `const` or `let` instead of `var` to declare variables to avoid polluting the global namespace. 

for details: https://hackernoon.com/js-var-let-or-const-67e51dbb716f