### PR TITLE
Remove unnecessary strict mode directive

### DIFF
--- a/lib/schnorr.js
+++ b/lib/schnorr.js
@@ -19,8 +19,6 @@
  * https://github.com/bcoin-org/bcoin
  */
 
-'use strict';
-
 const assert = require('assert');
 const elliptic = require('elliptic');
 const Signature = require('elliptic/lib/elliptic/ec/signature');


### PR DESCRIPTION
This PR removes unnecessary strict mode directive.

ES6 module code, which Babel expects by default, is automatically Strict Mode according to the ES6 spec.

For details: https://eslint.org/docs/rules/strict

Still we get build output like this:
zilliqa.min.js
``` javascript
(...) ({1:[function(e,t,r){"use strict";var i=e("./lib/zilliqa");"undefined"!=typeof window&&void 0===window.Zilliqa&&(window.Zilliqa=i),t.exports={Zilliqa:i}},{"./lib/zilliqa":6}],2:[function(e,t,r){t.exports={version:"0.0.1",defaultNodeUrl:"http://localhost:4201"}},{}],3:[function(e,t,r){"use strict";function i(e){u(e,{url:[c.isUrl]}),this.url=e.url,this.apiUrl="https://api.zilliqa.com"} (...)
```