### PR TITLE
Use const if never reassigned

### DIFF
--- a/lib/schnorr.js
+++ b/lib/schnorr.js
@@ -36,8 +36,8 @@ const schnorr = exports;
  */
 
 schnorr.hash = function hash(q, pubkey, msg) {
-  let totalLength = 66 + msg.byteLength // 33 q + 33 pubkey + variable msgLen
-  let Q = q.toArrayLike(Buffer, 'be', 33);
+  const totalLength = 66 + msg.byteLength // 33 q + 33 pubkey + variable msgLen
+  const Q = q.toArrayLike(Buffer, 'be', 33);
   const B = Buffer.allocUnsafe(totalLength);
 
   Q.copy(B, 0);
@@ -70,8 +70,8 @@ schnorr.trySign = function trySign(msg, prv, k, pn, pubKey) {
   if (k.gte(curve.n))
     return null;
 
-  let Q = curve.g.mul(k);
-  let compressedQ = new BN(Q.encodeCompressed());
+  const Q = curve.g.mul(k);
+  const compressedQ = new BN(Q.encodeCompressed());
 
   const r = schnorr.hash(compressedQ, pubKey, msg);
   const h = r.clone();
@@ -139,8 +139,8 @@ schnorr.verify = function verify(msg, signature, key) {
   const l = kpub.mul(sig.r);
   const r = curve.g.mul(sig.s);
 
-  let Q = l.add(r);
-  let compressedQ = new BN(Q.encodeCompressed());
+  const Q = l.add(r);
+  const compressedQ = new BN(Q.encodeCompressed());
 
   const r1 = schnorr.hash(compressedQ, key, msg);
 


### PR DESCRIPTION
This PR declares `const` instead of `let` only for those variables never reassigned. By doing so, readers can figure out which variables are reassigned. Therefore, it reduces cognitive load for readers and improves maintainability. 

For details: https://eslint.org/docs/rules/prefer-const