### PR TITLE
Changed the source of randomness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Zilliqa-JavaScript-Library API
+[![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs-lib.svg?style=flat-square)](https://gitter.im/Zilliqa/General)
 
 ## Installation
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,14 +11,15 @@
 var secp256k1 = require('bcrypto').secp256k1
 var sha256 = require('bcrypto').sha256
 var isWebUri = require('valid-url').isWebUri
-var schnorr = require('./schnorr')
+var schnorr = require('./schnorr');
+var crypto = require('crypto');
 
 
 module.exports = {
 // generate a new private key using the secp256k1 curve
 // returns a Buffer object, 
 generatePrivateKey: function () {
-	return secp256k1.generatePrivateKey()
+	return crypto.randomBytes(32);
 },
 
 // verify if the private key is valid for the secp256k1 curve
@@ -42,6 +43,14 @@ getAddressFromPrivateKey: function (privateKey) {
 	let address = pubKeyHash.toString('hex', 12) // rightmost 160 bits/20 bytes of the hash
 
 	return address
+},
+
+getAddressFromPublicKey: function (pubKey) {
+	if (typeof(pubKey) == 'string') {
+		pubKey = new Buffer(pubKey, 'hex')
+	}
+	let pubKeyHash = sha256.digest(pubKey) // sha256 hash of the public key
+	let address = pubKeyHash.toString('hex', 12) // rightmost 160 bits/20 bytes of the hash
 },
 
 getPubKeyFromPrivateKey: function (privateKey) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,8 +16,11 @@ var crypto = require('crypto');
 
 
 module.exports = {
+
 // generate a new private key using the secp256k1 curve
-// returns a Buffer object, 
+// returns a Buffer object,
+// @warning: generatePrivateKey should NOT be called in production systems.
+// @warning: wallet services should use their own cryptographically secure randomness
 generatePrivateKey: function () {
 	return crypto.randomBytes(32);
 },


### PR DESCRIPTION
## Description
Randomness was previously generated from third-party module (`bcrypto`). The package was created by bcoin (not Bitcoin-core, common misconception), and is still under active development. Since randomness is a strong security assumption, we should use only trusted source of randomness.

Since this is a node package, we should use the native `crypto` library. By using a `crypto` native, we are reducing the vectors of attack possible. 

In future, app developers should __NOT__ use this function at all to generate private keys!  Wallet apps should use their own sources of randomness (be it a hardware randomness generator, or some fancy way of creating randomness entropy using mouse movement).

## Review Suggestion
* Build the file, then test it with some simple node script to generate private keys and generate addresses. 

## Status

### Implementation
- [ ] **ready for review**

