### PR TITLE
Hotfix/validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ To get started, you have to specify the network and set some function definition
     Setting Up 
 */ 
 
-let { Zilliqa } = require('zilliqa.js');
+let { Zilliqa } = require('zilliqa-js');
 
 //For local testing, use URL = 'http://localhost:4201'
 //To connect to the external network, use URL = 'https://api-scilla.zilliqa.com'
-
+URL = 'https://api-scilla.zilliqa.com
 let zilliqa = new Zilliqa({
     nodeUrl: URL
 });

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -7,5 +7,5 @@
 // another public or private blockchain network. This source code is provided ‘as is’ and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed.
-const crypto = require('@trust/webcrypto');
-window.crypto = crypto;
+window.crypto = require('@trust/webcrypto');
+window.fetch = require('jest-fetch-mock');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "hash.js": "^1.1.5",
     "hmac-drbg": "^1.0.1",
     "randombytes": "^2.0.6",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.56",
@@ -65,6 +66,7 @@
     "gulp-util": "^3.0.8",
     "hoek": "^5.0.3",
     "jest": "^23.4.2",
+    "jest-fetch-mock": "^1.6.5",
     "jest-watch-typeahead": "^0.2.0",
     "mocha": "^5.2.0",
     "ts-jest": "^23.1.3",

--- a/src/__tests__/node.spec.ts
+++ b/src/__tests__/node.spec.ts
@@ -1,6 +1,7 @@
 import elliptic from 'elliptic';
 import BN from 'bn.js';
 import {pairs} from './keypairs.fixtures';
+import * as util from '../util';
 import Znode from '../node';
 import jestFetch from 'jest-fetch-mock';
 
@@ -8,9 +9,55 @@ const secp256k1 = elliptic.ec('secp256k1');
 const node = new Znode({url: 'http://localhost:4201'});
 const fetchMock = fetch as typeof jestFetch;
 
+const code = '(* HelloWorld contract *)\n\n\n(***************************************************)\n(*               Associated library                *)\n(***************************************************)\nlibrary HelloWorld\n\nlet one_msg = \n  fun (msg : Message) => \n  let nil_msg = Nil {Message} in\n  Cons {Message} msg nil_msg\n\nlet not_owner_code = Int32 1\nlet set_hello_code = Int32 2\n\n(***************************************************)\n(*             The contract definition             *)\n(***************************************************)\n\ncontract HelloWorld\n(owner: Address)\n\nfield welcome_msg : String = ""\n\ntransition setHello (msg : String)\n  is_owner = builtin eq owner _sender;\n  match is_owner with\n  | False =>\n    msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};\n    msgs = one_msg msg;\n    send msgs\n  | True =>\n    welcome_msg := msg;\n    msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};\n    msgs = one_msg msg;\n    send msgs\n  end\nend\n\n\ntransition getHello ()\n    r <- welcome_msg;\n    msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; msg : r};\n    msgs = one_msg msg;\n    send msgs\nend';
+
 describe('node', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
+  });
+
+  it('should be able to create transactions to 0x0', (done) => {
+    const privateKey = pairs[1].private;
+    const publicKey = secp256k1
+      .keyFromPrivate(privateKey, 'hex')
+      .getPublic(true, 'hex');
+
+    // the immutable initialisation variables
+    const initParams = [
+      {
+        vname: 'owner',
+        type: 'Address',
+        value: '0x1234567890123456789012345678901234567890',
+      },
+      {
+        vname: 'total_tokens',
+        type: 'Uint128',
+        value: '10000',
+      },
+    ];
+
+    const tx = {
+      version: 8,
+      nonce: 8,
+      to: '0000000000000000000000000000000000000000',
+      from: pairs[1].digest.slice(0, 40),
+      pubKey: publicKey,
+      amount: new BN('888', 10),
+      gasPrice: 8,
+      gasLimit: 88,
+      code: code,
+      data: JSON.stringify(initParams).replace(/\\"/g, '"'),
+    };
+
+    const signed = util.createTransactionJson(privateKey, tx);
+
+    const response = JSON.stringify({some: 'random_data'});
+    fetchMock.mockResponseOnce(response);
+    node.createTransaction(signed, (err, res) => {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(res)).toEqual(response);
+      done();
+    });
   });
 
   it('should be able to broadcast a well-formed transaction', (done) => {

--- a/src/__tests__/node.spec.ts
+++ b/src/__tests__/node.spec.ts
@@ -1,0 +1,45 @@
+import elliptic from 'elliptic';
+import BN from 'bn.js';
+import {pairs} from './keypairs.fixtures';
+import Znode from '../node';
+import jestFetch from 'jest-fetch-mock';
+
+const secp256k1 = elliptic.ec('secp256k1');
+const node = new Znode({url: 'http://localhost:4201'});
+const fetchMock = fetch as typeof jestFetch;
+
+describe('node', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it('should be able to broadcast a well-formed transaction', (done) => {
+    const privateKey = pairs[1].private;
+    const publicKey = secp256k1
+      .keyFromPrivate(privateKey, 'hex')
+      .getPublic(true, 'hex');
+
+    const tx = {
+      version: 8,
+      nonce: 8,
+      to: pairs[0].digest.slice(0, 40),
+      from: pairs[1].digest.slice(0, 40),
+      pubKey: publicKey,
+      amount: new BN('888', 10),
+      gasPrice: 8,
+      gasLimit: 88,
+      code: '',
+      data: '',
+    };
+
+    // setup mock response here
+    const response = JSON.stringify({some: 'random_data'});
+    fetchMock.mockResponseOnce(response);
+
+    node.createTransaction(tx, (err, res) => {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(res)).toEqual(response);
+      done();
+    });
+  });
+});

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
   it('should recover a public key from a private key', () => {
     pairs.forEach(({private: priv, public: expected}) => {
       const actual = util.getPubKeyFromPrivateKey(priv);
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(util.compressPublicKey(expected));
     });
   });
 

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -81,55 +81,6 @@ describe('utils', () => {
     expect(res).toBeTruthy();
   });
 
-  it('should be able to create transactions to 0x0', () => {
-    const privateKey = pairs[1].private;
-    const publicKey = secp256k1
-      .keyFromPrivate(privateKey, 'hex')
-      .getPublic(true, 'hex');
-
-    // contains the scilla code as a string
-    const code = 'Scilla Code';
-
-    // the immutable initialisation variables
-    const initParams = [
-      {
-        vname: 'owner',
-        type: 'Address',
-        value: '0x1234567890123456789012345678901234567890',
-      },
-      {
-        vname: 'total_tokens',
-        type: 'Uint128',
-        value: '10000',
-      },
-    ];
-
-    const tx = {
-      version: 8,
-      nonce: 8,
-      to: '0'.repeat(40),
-      from: pairs[1].digest.slice(0, 40),
-      pubKey: publicKey,
-      amount: new BN('888', 10),
-      gasPrice: 8,
-      gasLimit: 88,
-      code: code,
-      data: JSON.stringify(initParams).replace(/\\"/g, '"'),
-    };
-
-    const {signature} = util.createTransactionJson(privateKey, tx);
-    const res = schnorr.verify(
-      util.encodeTransaction(tx),
-      new Signature({
-        r: new BN((signature as string).slice(0, 64), 16),
-        s: new BN((signature as string).slice(64), 16),
-      }),
-      new Buffer(publicKey, 'hex'),
-    );
-
-    expect(res).toBeTruthy();
-  });
-
   it('should sign messages correctly', () => {
     const privateKey = pairs[1].private;
     const publicKey = secp256k1

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -81,6 +81,55 @@ describe('utils', () => {
     expect(res).toBeTruthy();
   });
 
+  it('should be able to create transactions to 0x0', () => {
+    const privateKey = pairs[1].private;
+    const publicKey = secp256k1
+      .keyFromPrivate(privateKey, 'hex')
+      .getPublic(true, 'hex');
+
+    // contains the scilla code as a string
+    const code = 'Scilla Code';
+
+    // the immutable initialisation variables
+    const initParams = [
+      {
+        vname: 'owner',
+        type: 'Address',
+        value: '0x1234567890123456789012345678901234567890',
+      },
+      {
+        vname: 'total_tokens',
+        type: 'Uint128',
+        value: '10000',
+      },
+    ];
+
+    const tx = {
+      version: 8,
+      nonce: 8,
+      to: '0'.repeat(40),
+      from: pairs[1].digest.slice(0, 40),
+      pubKey: publicKey,
+      amount: new BN('888', 10),
+      gasPrice: 8,
+      gasLimit: 88,
+      code: code,
+      data: JSON.stringify(initParams).replace(/\\"/g, '"'),
+    };
+
+    const {signature} = util.createTransactionJson(privateKey, tx);
+    const res = schnorr.verify(
+      util.encodeTransaction(tx),
+      new Signature({
+        r: new BN((signature as string).slice(0, 64), 16),
+        s: new BN((signature as string).slice(64), 16),
+      }),
+      new Buffer(publicKey, 'hex'),
+    );
+
+    expect(res).toBeTruthy();
+  });
+
   it('should sign messages correctly', () => {
     const privateKey = pairs[1].private;
     const publicKey = secp256k1

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -12,7 +12,7 @@ describe('utils', () => {
   it('should be able to generate a valid 32-byte private key', () => {
     const pk = util.generatePrivateKey();
 
-    expect(pk.slice(2)).toHaveLength(64);
+    expect(pk).toHaveLength(64);
     expect(util.verifyPrivateKey(pk)).toBeTruthy();
   });
 

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -1,4 +1,5 @@
 import elliptic from 'elliptic';
+import Signature from 'elliptic/lib/elliptic/ec/signature';
 import BN from 'bn.js';
 import hashjs from 'hash.js';
 import {pairs} from './keypairs.fixtures';
@@ -46,6 +47,38 @@ describe('utils', () => {
     expect(actual).toHaveLength(40);
     expect(actual).toEqual(hash.slice(0, 40));
     expect(actual).toEqual(expected);
+  });
+
+  it('should be able to correctly create transaction json', () => {
+    const privateKey = pairs[1].private;
+    const publicKey = secp256k1
+      .keyFromPrivate(privateKey, 'hex')
+      .getPublic(true, 'hex');
+
+    const tx = {
+      version: 8,
+      nonce: 8,
+      to: pairs[0].digest.slice(0, 40),
+      from: pairs[1].digest.slice(0, 40),
+      pubKey: publicKey,
+      amount: new BN('888', 10),
+      gasPrice: 8,
+      gasLimit: 88,
+      code: '',
+      data: '',
+    };
+
+    const {signature} = util.createTransactionJson(privateKey, tx);
+    const res = schnorr.verify(
+      util.encodeTransaction(tx),
+      new Signature({
+        r: new BN((signature as string).slice(0, 64), 16),
+        s: new BN((signature as string).slice(64), 16),
+      }),
+      new Buffer(publicKey, 'hex'),
+    );
+
+    expect(res).toBeTruthy();
   });
 
   it('should sign messages correctly', () => {

--- a/src/node.ts
+++ b/src/node.ts
@@ -8,7 +8,7 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed.
 import BN from 'bn.js';
-import { validateArgs } from './util';
+import {validateArgs} from './util';
 import * as util from './util';
 
 type callback = (error: any, data: any) => any;
@@ -70,7 +70,12 @@ export default class ZNode {
       return;
     }
 
-    rpcAjax(this.url, 'CreateTransaction', args, cb);
+    rpcAjax(
+      this.url,
+      'CreateTransaction',
+      {...args, amount: args.amount.toString(10)},
+      cb,
+    );
   };
 
   getTransaction = (args, cb) => {
@@ -115,7 +120,7 @@ export default class ZNode {
     rpcAjax(this.url, 'GetBalance', args.address, cb);
   };
 
-  getGasPrice = (cb) => {
+  getGasPrice = cb => {
     rpcAjax(this.url, 'GetGasPrice', '', cb);
   };
 
@@ -263,7 +268,7 @@ export default class ZNode {
     rpcAjax(this.url, 'GetTransactionReceipt', args.txHash, cb);
   };
 
-  getHashrate = (cb) => {
+  getHashrate = cb => {
     rpcAjax(this.url, 'GetHashrate', '', cb);
   };
 
@@ -384,4 +389,3 @@ function postData(url, data) {
     referrer: 'no-referrer',
   }).then(response => response.json());
 }
-

--- a/src/node.ts
+++ b/src/node.ts
@@ -7,7 +7,7 @@
 // another public or private blockchain network. This source code is provided ‘as is’ and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed.
-import fetch from 'cross-fetch';
+import BN from 'bn.js';
 import { validateArgs } from './util';
 import * as util from './util';
 
@@ -61,7 +61,7 @@ export default class ZNode {
       validateArgs(args, {
         to: [util.isAddress],
         pubKey: [util.isPubkey],
-        amount: [util.isNumber],
+        amount: [BN.isBN],
         gasPrice: [util.isNumber],
         gasLimit: [util.isNumber],
       });

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@
 // another public or private blockchain network. This source code is provided ‘as is’ and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+import BN from 'bn.js';
 import randomBytes from 'randombytes';
 import elliptic from 'elliptic';
 import hashjs from 'hash.js';
@@ -63,14 +64,25 @@ export const getAddressFromPrivateKey = (privateKey: string) => {
  * getPubKeyFromPrivateKey
  *
  * takes a hex-encoded string (private key) and returns its corresponding
- * hex-encoded 32-byte public key.
+ * hex-encoded 33-byte public key.
  *
  * @param {string} privateKey
  * @returns {string}
  */
 export const getPubKeyFromPrivateKey = (privateKey: string) => {
   const keyPair = secp256k1.keyFromPrivate(privateKey, 'hex');
-  return keyPair.getPublic(false, 'hex');
+  return keyPair.getPublic(true, 'hex');
+};
+
+/**
+ * compressPublicKey
+ *
+ * @param {string} publicKey - 65-byte public key, a point (x, y)
+ *
+ * @returns {string}
+ */
+export const compressPublicKey = (publicKey: string): string => {
+  return secp256k1.keyFromPublic(publicKey, 'hex').getPublic(true, 'hex');
 };
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,9 +151,7 @@ export const createTransactionJson = (
   privateKey: string,
   txnDetails: TxDetails,
 ): TxDetails => {
-  const pubKey = secp256k1
-    .keyFromPrivate(privateKey, 'hex')
-    .getPublic(true, 'hex');
+  const pubKey = getPubKeyFromPrivateKey(privateKey);
 
   const txn = {
     version: txnDetails.version,

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,6 @@
 // another public or private blockchain network. This source code is provided ‘as is’ and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose
 // and, to the extent permitted by law, all liability for your use of the code is disclaimed.
-import BN from 'bn.js';
 import randomBytes from 'randombytes';
 import elliptic from 'elliptic';
 import hashjs from 'hash.js';
@@ -17,7 +16,7 @@ import * as schnorr from './schnorr';
 import {TxDetails} from './types';
 
 const NUM_BYTES = 32;
-const HEX_PREFIX = '0x';
+//const HEX_PREFIX = '0x';
 
 const secp256k1 = elliptic.ec('secp256k1');
 
@@ -27,7 +26,7 @@ const secp256k1 = elliptic.ec('secp256k1');
  * @returns {string} - the hex-encoded private key
  */
 export const generatePrivateKey = (): string => {
-  let priv = HEX_PREFIX;
+  let priv = '';
   const rand = randomBytes(NUM_BYTES);
 
   for (let i = 0; i < rand.byteLength; i++) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -153,7 +153,7 @@ export const createTransactionJson = (
 ): TxDetails => {
   const pubKey = secp256k1
     .keyFromPrivate(privateKey, 'hex')
-    .getPublic(false, 'hex');
+    .getPublic(true, 'hex');
 
   const txn = {
     version: txnDetails.version,

--- a/typings/elliptic.d.ts
+++ b/typings/elliptic.d.ts
@@ -38,7 +38,7 @@ declare module 'elliptic' {
     interface EC {
       curve: Curve;
       keyFromPrivate(priv: string, enc: string): KeyPair;
-      keyFromPublic(pub: BN, enc: string): KeyPair;
+      keyFromPublic(pub: string, enc: string): KeyPair;
     }
 
     interface KeyPair {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,10 @@ const UglifyJs = require('uglifyjs-webpack-plugin');
 
 const baseConfig = {
   entry: {
-    zilliqa: './src/index.ts',
+    zilliqa: [
+      'whatwg-fetch',
+      './src/index.ts'
+    ],
   },
   mode: 'production',
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@
     node-rsa "^0.4.0"
     text-encoding "^0.6.1"
 
-"@types/jest@^23.3.1":
+"@types/jest@^23.0.0", "@types/jest@^23.3.1":
   version "23.3.1"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
 
@@ -2459,7 +2459,7 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-encoding@^0.1.12:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
@@ -3653,7 +3653,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3708,6 +3708,13 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3878,6 +3885,14 @@ jest-environment-node@^23.4.0:
   dependencies:
     jest-mock "^23.2.0"
     jest-util "^23.4.0"
+
+jest-fetch-mock@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.6.5.tgz#178fa1a937ef6f61fb8e8483b6d4602b17e0d96d"
+  dependencies:
+    "@types/jest" "^23.0.0"
+    isomorphic-fetch "^2.2.1"
+    promise-polyfill "^7.1.1"
 
 jest-get-type@^22.1.0:
   version "22.4.3"
@@ -4815,6 +4830,13 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -5393,6 +5415,10 @@ process@^0.11.10, process@~0.11.0:
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+
+promise-polyfill@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
 
 prompts@^0.1.9:
   version "0.1.14"
@@ -6896,7 +6922,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@2.0.4:
+whatwg-fetch@2.0.4, whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 


### PR DESCRIPTION
## Description

This PR fixes:
- Full-fat public keys are now compressed, so all methods returning public keys should return 33 bytes instead of 65
- Validation for `amount` field in transactions should now correctly accept instances of `BN`
- Test case added for the misbehaving method
- Adds `whatwg-fetch` as a global polyfill

## Review Suggestion

- Test built file with node (fetch polyfill)