### PR TITLE
Cast `amount` to `number`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let { Zilliqa } = require('zilliqa-js');
 
 //For local testing, use URL = 'http://localhost:4201'
 //To connect to the external network, use URL = 'https://api-scilla.zilliqa.com'
-URL = 'https://api-scilla.zilliqa.com
+let URL = 'https://api-scilla.zilliqa.com'
 let zilliqa = new Zilliqa({
     nodeUrl: URL
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zilliqa-js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "SEE LICENSE in LICENSE",
   "description": "zilliqa js library",
   "repository": "https://github.com/Zilliqa/Zilliqa-Javascript-Library",

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -59,7 +59,6 @@ describe('utils', () => {
       version: 8,
       nonce: 8,
       to: pairs[0].digest.slice(0, 40),
-      from: pairs[1].digest.slice(0, 40),
       pubKey: publicKey,
       amount: new BN('888', 10),
       gasPrice: 8,
@@ -91,7 +90,6 @@ describe('utils', () => {
       version: 8,
       nonce: 8,
       to: pairs[0].digest.slice(0, 40),
-      from: pairs[1].digest.slice(0, 40),
       pubKey: publicKey,
       amount: new BN('888', 10),
       gasPrice: 8,
@@ -114,12 +112,10 @@ describe('utils', () => {
   it('should match the C++ implementation', () => {
     schnorrVectors.forEach(({priv, k, r, s}, idx) => {
       const pub = secp256k1.keyFromPrivate(priv, 'hex').getPublic(false, 'hex');
-      const fromIdx = idx === schnorrVectors.length - 1 ? idx - 2 : idx + 1;
 
       const tx = {
         version: 8,
         nonce: 8,
-        from: util.getAddressFromPrivateKey(schnorrVectors[fromIdx].priv),
         to: util.getAddressFromPublicKey(pub),
         pubKey: pub,
         amount: new BN('888', 10),

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -33,19 +33,13 @@ describe('utils', () => {
   });
 
   it('should be able to recover an address from a private key', () => {
-    const pk = util.generatePrivateKey();
-    const publicKey = secp256k1
-      .keyFromPrivate(pk, 'hex')
-      .getPublic(false, 'hex');
-    const hash = hashjs
-      .sha256()
-      .update(publicKey)
-      .digest('hex');
-    const expected = hash.slice(0, 40);
-    const actual = util.getAddressFromPrivateKey(pk);
+    const [pair] = pairs;
+    const expected = util.getAddressFromPublicKey(
+      util.compressPublicKey(pair.public),
+    );
+    const actual = util.getAddressFromPrivateKey(pair.private);
 
     expect(actual).toHaveLength(40);
-    expect(actual).toEqual(hash.slice(0, 40));
     expect(actual).toEqual(expected);
   });
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -73,7 +73,9 @@ export default class ZNode {
     rpcAjax(
       this.url,
       'CreateTransaction',
-      {...args, amount: args.amount.toString(10)},
+      // FIXME: core must be able to parse amount as string; it currently does
+      // not. the issue is being tracked here: https://github.com/Zilliqa/Zilliqa/issues/524
+      {...args, amount: args.amount.toNumber()},
       cb,
     );
   };

--- a/src/schnorr.ts
+++ b/src/schnorr.ts
@@ -51,7 +51,7 @@ export const hash = (q: BN, pubkey: Buffer, msg: Buffer) => {
   pubkey.copy(B, 33);
   msg.copy(B, 66);
 
-  return new BN(sha256.update(B).digest('hex'));
+  return new BN(sha256.update(B).digest('hex'), 16);
 };
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,7 +50,7 @@ export const generatePrivateKey = (): string => {
  */
 export const getAddressFromPrivateKey = (privateKey: string) => {
   const keyPair = secp256k1.keyFromPrivate(privateKey, 'hex');
-  const pub = keyPair.getPublic(false, 'hex');
+  const pub = keyPair.getPublic(true, 'hex');
 
   return hashjs
     .sha256()


### PR DESCRIPTION
As noted in commit ca0b799f7f20787c6e69db91d868cef9eef27be3, we are temporarily casting `amount` from `BN` to `number` until such time as https://github.com/Zilliqa/Zilliqa/issues/524 is resolved.

@AmritKumar @edisonljh 