### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -83,7 +83,7 @@ describe('utils', () => {
         r: new BN((signature as string).slice(0, 64), 16),
         s: new BN((signature as string).slice(64), 16),
       }),
-      new Buffer(publicKey, 'hex'),
+      Buffer.from(publicKey, 'hex'),
     );
 
     expect(res).toBeTruthy();
@@ -122,10 +122,10 @@ describe('utils', () => {
     const encodedTx = util.encodeTransaction(tx);
     const sig = schnorr.sign(
       encodedTx,
-      new Buffer(privateKey, 'hex'),
-      new Buffer(publicKey, 'hex'),
+      Buffer.from(privateKey, 'hex'),
+      Buffer.from(publicKey, 'hex'),
     );
-    const res = schnorr.verify(encodedTx, sig, new Buffer(publicKey, 'hex'));
+    const res = schnorr.verify(encodedTx, sig, Buffer.from(publicKey, 'hex'));
 
     expect(res).toBeTruthy();
   });
@@ -153,14 +153,14 @@ describe('utils', () => {
       while (!sig) {
         sig = schnorr.trySign(
           encodedTx,
-          new BN(new Buffer(badPrivateKey, 'hex')),
+          new BN(Buffer.from(badPrivateKey, 'hex')),
           new BN(k),
-          new Buffer(''),
-          new Buffer(pub, 'hex'),
+          Buffer.from(''),
+          Buffer.from(pub, 'hex'),
         );
       }
 
-      const res = schnorr.verify(encodedTx, sig, new Buffer(pub, 'hex'));
+      const res = schnorr.verify(encodedTx, sig, Buffer.from(pub, 'hex'));
       expect(res).toBeFalsy();
     });
   });
@@ -170,18 +170,18 @@ describe('utils', () => {
       let sig: Signature | null = null;
       while (!sig) {
         sig = schnorr.trySign(
-          new Buffer(msg, 'hex'),
-          new BN(new Buffer(priv, 'hex')),
+          Buffer.from(msg, 'hex'),
+          new BN(Buffer.from(priv, 'hex')),
           new BN(k, 16),
-          new Buffer(''),
-          new Buffer(pub, 'hex'),
+          Buffer.from(''),
+          Buffer.from(pub, 'hex'),
         );
       }
 
       const res = schnorr.verify(
-        new Buffer(msg, 'hex'),
+        Buffer.from(msg, 'hex'),
         sig,
-        new Buffer(pub, 'hex'),
+        Buffer.from(pub, 'hex'),
       );
 
       expect(sig.r.toString('hex', 64).toUpperCase()).toEqual(r);

--- a/src/util.ts
+++ b/src/util.ts
@@ -119,8 +119,8 @@ export const verifyPrivateKey = (privateKey: string): boolean => {
  * @returns {Buffer}
  */
 export const encodeTransaction = (txn: TxDetails) => {
-  let codeHex = new Buffer(txn.code).toString('hex');
-  let dataHex = new Buffer(txn.data).toString('hex');
+  let codeHex = Buffer.from(txn.code).toString('hex');
+  let dataHex = Buffer.from(txn.data).toString('hex');
 
   let encoded =
     intToByteArray(txn.version, 64).join('') +
@@ -135,7 +135,7 @@ export const encodeTransaction = (txn: TxDetails) => {
     intToByteArray(txn.data.length, 8).join('') + // size of data
     dataHex;
 
-  return new Buffer(encoded, 'hex');
+  return Buffer.from(encoded, 'hex');
 };
 
 /**
@@ -170,8 +170,8 @@ export const createTransactionJson = (
   // sign using schnorr lib
   const sig = schnorr.sign(
     encodedTx,
-    new Buffer(privateKey, 'hex'),
-    new Buffer(pubKey, 'hex'),
+    Buffer.from(privateKey, 'hex'),
+    Buffer.from(pubKey, 'hex'),
   );
 
   let r = sig.r.toString('hex');


### PR DESCRIPTION
## Description
This PR replaces all `new Buffer` _which is deprecated and unsafe_ with `Buffer.from`
We should not use deprecated/unsafe Buffer constructor.

The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe