### PR TITLE
Use triple equals instead of double equals

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -203,7 +203,7 @@ export const validateArgs = (
     if (args[key] === undefined) throw new Error('Key not found: ' + key);
 
     for (var i = 0; i < requiredArgs[key].length; i++) {
-      if (typeof requiredArgs[key][i] != 'function')
+      if (typeof requiredArgs[key][i] !== 'function')
         throw new Error('Validator is not a function');
 
       if (!requiredArgs[key][i](args[key]))
@@ -215,7 +215,7 @@ export const validateArgs = (
     for (var key in optionalArgs) {
       if (args[key]) {
         for (var i = 0; i < optionalArgs[key].length; i++) {
-          if (typeof optionalArgs[key][i] != 'function')
+          if (typeof optionalArgs[key][i] !== 'function')
             throw new Error('Validator is not a function');
 
           if (!optionalArgs[key][i](args[key]))
@@ -249,11 +249,11 @@ export const isHash = (txHash: string) => {
 };
 
 export const isNumber = (number: any) => {
-  return typeof number == 'number';
+  return typeof number === 'number';
 };
 
 export const isString = (string: any) => {
-  return typeof string == 'string';
+  return typeof string === 'string';
 };
 
 // convert number to array representing the padded hex form


### PR DESCRIPTION
## Description
This PR replaces all double equals with triple equals.
(`!=` or `==`)  =>   (`!==` or `===`)

It is considered good practice to use the type-safe equality operators === and !== instead of their regular counterparts == and !=. The reason for this is that == and != do type coercion which follows the rather obscure Abstract Equality Comparison Algorithm. For instance, the following statements are all considered true:

* [] == false
* [] == ![]
* 3 == "03"

If one of those occurs in an innocent-looking statement such as a == b the actual problem is very difficult to spot.

Check this out: https://eslint.org/docs/rules/eqeqeq
