### PR TITLE
Fix/bn.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 install:
   - yarn install
   - yarn global add codecov
+  - yarn global add ts-node
 script:
   - yarn bootstrap
   - yarn run test

--- a/packages/zilliqa-js-account/package.json
+++ b/packages/zilliqa-js-account/package.json
@@ -19,13 +19,11 @@
   },
   "dependencies": {
     "@types/bip39": "^2.4.0",
-    "@types/bn.js": "^4.11.3",
     "@types/hdkey": "^0.7.0",
     "@zilliqa-js/core": "^0.2.2",
     "@zilliqa-js/crypto": "^0.2.2",
     "@zilliqa-js/util": "^0.2.2",
     "bip39": "^2.5.0",
-    "bn.js": "^4.11.8",
     "hdkey": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/zilliqa-js-account/src/transaction.ts
+++ b/packages/zilliqa-js-account/src/transaction.ts
@@ -1,8 +1,6 @@
-import BN from 'bn.js';
-
 import { Provider, RPCResponse, Signable } from '@zilliqa-js/core';
 import { getAddressFromPublicKey } from '@zilliqa-js/crypto';
-import { types } from '@zilliqa-js/util';
+import { BN, types } from '@zilliqa-js/util';
 
 import { TxParams, TxReceipt, TxStatus, TxIncluded } from './types';
 import { encodeTransactionProto, sleep } from './util';

--- a/packages/zilliqa-js-account/src/types.ts
+++ b/packages/zilliqa-js-account/src/types.ts
@@ -1,4 +1,4 @@
-import BN from 'bn.js';
+import { BN } from '@zilliqa-js/util';
 
 export const enum TxStatus {
   Initialised,

--- a/packages/zilliqa-js-account/src/util.ts
+++ b/packages/zilliqa-js-account/src/util.ts
@@ -1,5 +1,6 @@
 import { ReqMiddlewareFn, RPCMethod } from '@zilliqa-js/core';
 import { bytes, validation } from '@zilliqa-js/util';
+// tslint:disable-next-line
 import { ZilliqaMessage } from 'proto';
 import { TxReceipt, TxParams } from './types';
 

--- a/packages/zilliqa-js-account/src/util.ts
+++ b/packages/zilliqa-js-account/src/util.ts
@@ -43,13 +43,13 @@ export const encodeTransactionProto = (tx: TxParams): Buffer => {
       data: bytes.hexToByteArray(tx.pubKey || '00'),
     }),
     amount: ZilliqaMessage.ByteArray.create({
-      data: Uint8Array.from(tx.amount.toBuffer(undefined, 32)),
+      data: Uint8Array.from(tx.amount.toArrayLike(Buffer, undefined, 32)),
     }),
     gasprice: ZilliqaMessage.ByteArray.create({
-      data: Uint8Array.from(tx.gasPrice.toBuffer(undefined, 32)),
+      data: Uint8Array.from(tx.gasPrice.toArrayLike(Buffer, undefined, 32)),
     }),
     gaslimit: ZilliqaMessage.ByteArray.create({
-      data: Uint8Array.from(tx.gasLimit.toBuffer(undefined, 32)),
+      data: Uint8Array.from(tx.gasLimit.toArrayLike(Buffer, undefined, 32)),
     }),
     code: Uint8Array.from(
       [...(tx.code || '')].map((c) => <number>c.charCodeAt(0)),

--- a/packages/zilliqa-js-blockchain/package.json
+++ b/packages/zilliqa-js-blockchain/package.json
@@ -19,9 +19,8 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@types/bn.js": "^4.11.3",
     "@zilliqa-js/account": "^0.2.2",
     "@zilliqa-js/core": "^0.2.2",
-    "bn.js": "^4.11.8"
+    "@zilliqa-js/util": "^0.2.2"
   }
 }

--- a/packages/zilliqa-js-blockchain/src/util.ts
+++ b/packages/zilliqa-js-blockchain/src/util.ts
@@ -1,7 +1,6 @@
-import BN from 'bn.js';
-
 import { TxParams } from '@zilliqa-js/account';
 import { RPCResponse } from '@zilliqa-js/core';
+import { BN } from '@zilliqa-js/util';
 
 import { TransactionObj } from './types';
 

--- a/packages/zilliqa-js-contract/package.json
+++ b/packages/zilliqa-js-contract/package.json
@@ -19,12 +19,10 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@types/bn.js": "^4.11.3",
     "@zilliqa-js/account": "^0.2.2",
     "@zilliqa-js/blockchain": "^0.2.2",
     "@zilliqa-js/core": "^0.2.2",
     "@zilliqa-js/util": "^0.2.2",
-    "bn.js": "^4.11.8",
     "hash.js": "^1.1.5"
   }
 }

--- a/packages/zilliqa-js-contract/src/contract.ts
+++ b/packages/zilliqa-js-contract/src/contract.ts
@@ -1,8 +1,6 @@
-import BN from 'bn.js';
-
 import { Wallet, Transaction, TxStatus } from '@zilliqa-js/account';
 import { RPCMethod, Provider, sign } from '@zilliqa-js/core';
-import { types } from '@zilliqa-js/util';
+import { BN, types } from '@zilliqa-js/util';
 
 import { Contracts } from './factory';
 import {

--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -18,10 +18,8 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@types/bn.js": "^4.11.3",
     "@zilliqa-js/util": "^0.2.2",
     "aes-js": "^3.1.1",
-    "bn.js": "^4.11.8",
     "bsert": "^0.0.4",
     "elliptic": "^6.4.1",
     "hash.js": "^1.1.5",

--- a/packages/zilliqa-js-crypto/src/schnorr.ts
+++ b/packages/zilliqa-js-crypto/src/schnorr.ts
@@ -1,7 +1,8 @@
 import elliptic from 'elliptic';
-import BN from 'bn.js';
 import hashjs from 'hash.js';
 import DRBG from 'hmac-drbg';
+
+import { BN } from '@zilliqa-js/util';
 
 import { randomBytes } from './random';
 import { Signature } from './signature';

--- a/packages/zilliqa-js-crypto/src/signature.ts
+++ b/packages/zilliqa-js-crypto/src/signature.ts
@@ -1,4 +1,4 @@
-import BN from 'bn.js';
+import { BN } from '@zilliqa-js/util';
 
 /**
  * Signature

--- a/packages/zilliqa-js-util/README.md
+++ b/packages/zilliqa-js-util/README.md
@@ -1,6 +1,14 @@
 # @zilliqa-js/util
 > Utility functions useful in Zilliqa-related programs.
 
+## Classes
+
+### `BN`
+
+See documentation at [bn.js](https://github.com/indutny/bn.js/). This is
+simply a re-export of that library to prevent bloating other `@zilliqa-js`
+packages, most of which depend on `bn.js` in small ways.
+
 ## Functions
 
 ### `intToHexArray(int: number, size: number): string[]`

--- a/packages/zilliqa-js-util/src/index.ts
+++ b/packages/zilliqa-js-util/src/index.ts
@@ -1,5 +1,6 @@
 import * as bytes from './bytes';
 import * as types from './types';
 import * as validation from './validation';
+import BN from 'bn.js';
 
-export { bytes, types, validation };
+export { BN, bytes, types, validation };

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
   "rules": {
     "interface-name": [true, "never-prefix"],
     "member-access": false,
-    "no-angle-brack-type-assertion": false,
+    "no-angle-bracket-type-assertion": false,
     "no-bitwise": false,
     "no-console": false,
     "no-default-export": true,


### PR DESCRIPTION
This exposes `BN` from `@zilliqa-js/util`, in order to avoid needlessly pulling duplicate copies into various `@zilliqa-js` bundles. It also absolves consuming developers from needing to install their own copy of `bn.js`, which may be inconsistent with the interface expected by `@zilliqa-js` modules.

This should only be merged after PR #80.