### PR TITLE
v0.2.10

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.2.9",
+  "version": "0.2.10",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/zilliqa-js-account/package.json
+++ b/packages/zilliqa-js-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/account",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Used for signing transactions.",
   "main": "dist/index.js",
   "node": "dist/index.js",
@@ -20,10 +20,10 @@
   "dependencies": {
     "@types/bip39": "^2.4.0",
     "@types/hdkey": "^0.7.0",
-    "@zilliqa-js/core": "0.2.9",
-    "@zilliqa-js/crypto": "0.2.9",
-    "@zilliqa-js/proto": "0.2.9",
-    "@zilliqa-js/util": "0.2.9",
+    "@zilliqa-js/core": "0.2.10",
+    "@zilliqa-js/crypto": "0.2.10",
+    "@zilliqa-js/proto": "0.2.10",
+    "@zilliqa-js/util": "0.2.10",
     "bip39": "^2.5.0",
     "hdkey": "^1.1.0"
   },

--- a/packages/zilliqa-js-blockchain/package.json
+++ b/packages/zilliqa-js-blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/blockchain",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Class(es) for interacting with the Zilliqa blockchain.",
   "main": "dist/index.js",
   "node": "dist/index.js",
@@ -19,8 +19,8 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@zilliqa-js/account": "0.2.9",
-    "@zilliqa-js/core": "0.2.9",
-    "@zilliqa-js/util": "0.2.9"
+    "@zilliqa-js/account": "0.2.10",
+    "@zilliqa-js/core": "0.2.10",
+    "@zilliqa-js/util": "0.2.10"
   }
 }

--- a/packages/zilliqa-js-contract/package.json
+++ b/packages/zilliqa-js-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/contract",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Contract-related functionality.",
   "main": "dist/index.js",
   "node": "dist/index.js",
@@ -19,10 +19,10 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@zilliqa-js/account": "0.2.9",
-    "@zilliqa-js/blockchain": "0.2.9",
-    "@zilliqa-js/core": "0.2.9",
-    "@zilliqa-js/util": "0.2.9",
+    "@zilliqa-js/account": "0.2.10",
+    "@zilliqa-js/blockchain": "0.2.10",
+    "@zilliqa-js/core": "0.2.10",
+    "@zilliqa-js/util": "0.2.10",
     "hash.js": "^1.1.5"
   }
 }

--- a/packages/zilliqa-js-core/package.json
+++ b/packages/zilliqa-js-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Core abstractions that power the zilliqa JS client.",
   "main": "dist/index.js",
   "node": "dist/index.js",

--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/crypto",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Core crypto utilities for signing/verification/hashing Zilliqa transactions.",
   "main": "dist/index.js",
   "node": "dist/index.js",
@@ -18,7 +18,7 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@zilliqa-js/util": "0.2.9",
+    "@zilliqa-js/util": "0.2.10",
     "aes-js": "^3.1.1",
     "bsert": "^0.0.4",
     "elliptic": "^6.4.1",

--- a/packages/zilliqa-js-crypto/src/schnorr.ts
+++ b/packages/zilliqa-js-crypto/src/schnorr.ts
@@ -9,6 +9,7 @@ import { Signature } from './signature';
 
 const secp256k1 = elliptic.ec('secp256k1');
 const curve = secp256k1.curve;
+const PRIVKEY_SIZE_BYTES = 32;
 // Public key is a point (x, y) on the curve.
 // Each coordinate requires 32 bytes.
 // In its compressed form it suffices to store the x co-ordinate
@@ -36,8 +37,10 @@ export const generatePrivateKey = (): string => {
       entropyEnc: HEX_ENC,
       pers: 'zilliqajs+secp256k1+SHA256',
     })
-    .getPrivate(HEX_ENC);
+    .getPrivate()
+    .toString(16, PRIVKEY_SIZE_BYTES * 2);
 };
+
 /**
  * Hash (r | M).
  * @param {Buffer} msg

--- a/packages/zilliqa-js-proto/package.json
+++ b/packages/zilliqa-js-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/proto",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Protobuf dependencies for message serialization",
   "main": "dist/index.js",
   "node": "dist/index.js",

--- a/packages/zilliqa-js-util/package.json
+++ b/packages/zilliqa-js-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/util",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Utilities for working with Zillia.",
   "main": "dist/index.js",
   "node": "dist/index.js",

--- a/packages/zilliqa/package.json
+++ b/packages/zilliqa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zilliqa-js/zilliqa",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Main entry point to the Zilliqa JS client.",
   "main": "dist/index.js",
   "node": "dist/index.js",
@@ -16,11 +16,11 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@zilliqa-js/account": "0.2.9",
-    "@zilliqa-js/blockchain": "0.2.9",
-    "@zilliqa-js/contract": "0.2.9",
-    "@zilliqa-js/core": "0.2.9",
-    "@zilliqa-js/crypto": "0.2.9",
-    "@zilliqa-js/util": "0.2.9"
+    "@zilliqa-js/account": "0.2.10",
+    "@zilliqa-js/blockchain": "0.2.10",
+    "@zilliqa-js/contract": "0.2.10",
+    "@zilliqa-js/core": "0.2.10",
+    "@zilliqa-js/crypto": "0.2.10",
+    "@zilliqa-js/util": "0.2.10"
   }
 }


### PR DESCRIPTION
This fix ensures that the private key returned by `schnorr.generatePrivateKey` always has the right length of 32 bytes (64 hexadecimal characters).