### PR TITLE
fix(transaction): add `getToAddr` to prevent base58Decode loop

### DIFF
--- a/packages/zilliqa-js-account/src/transaction.ts
+++ b/packages/zilliqa-js-account/src/transaction.ts
@@ -79,11 +79,7 @@ export class Transaction implements Signable {
     return {
       version: this.version,
       // TODO: do not strip 0x after implementation on core side
-      toAddr: toChecksumAddress(
-        validation.isBase58(this.toAddr)
-          ? decodeBase58(this.toAddr)
-          : this.toAddr,
-      ).slice(2),
+      toAddr: toChecksumAddress(this.getToAddr(this.toAddr)).slice(2),
       nonce: this.nonce,
       pubKey: this.pubKey,
       amount: this.amount,
@@ -195,6 +191,20 @@ export class Transaction implements Signable {
   setStatus(status: TxStatus) {
     this.status = status;
     return this;
+  }
+
+  getToAddr(addr: string): string {
+    let result = '';
+    if (validation.isAddress(addr)) {
+      result = addr;
+    } else if (validation.isBase58(addr)) {
+      result = decodeBase58(addr);
+    }
+    if (validation.isAddress(result)) {
+      return result;
+    } else {
+      throw new Error('Address is not correct');
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
To ensure address check is correct 
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
When we use wallet.sign/signWith, `Transaction.map` will pass the txParams to it again, since we had strip '0x' before it is passed to Transaction, after that, the `validation.isBase58` may happen(rarely but possible).

For safety, we should add a `getToAddr` function to ensure it is valid.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Run unit tests and integration test
## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x ] **ready for review**

