### PR TITLE
fix: force `toAddr` to be either checksum or bech32

### DIFF
--- a/packages/zilliqa-js-account/src/transaction.ts
+++ b/packages/zilliqa-js-account/src/transaction.ts
@@ -7,7 +7,7 @@ import {
 import {
   fromBech32Address,
   getAddressFromPublicKey,
-  toChecksumAddress,
+  isValidChecksumAddress,
 } from '@zilliqa-js/crypto';
 import { BN, Long, validation } from '@zilliqa-js/util';
 
@@ -78,7 +78,6 @@ export class Transaction implements Signable {
   get txParams(): TxParams {
     return {
       version: this.version,
-      // TODO: do not strip 0x after implementation on core side
       toAddr: this.normaliseAddress(this.toAddr),
       nonce: this.nonce,
       pubKey: this.pubKey,
@@ -116,7 +115,7 @@ export class Transaction implements Signable {
   ) {
     // private members
     this.version = params.version;
-    this.toAddr = params.toAddr;
+    this.toAddr = this.normaliseAddress(params.toAddr);
     this.nonce = params.nonce;
     this.pubKey = params.pubKey;
     this.amount = params.amount;
@@ -254,7 +253,7 @@ export class Transaction implements Signable {
 
   private setParams(params: TxParams) {
     this.version = params.version;
-    this.toAddr = params.toAddr;
+    this.toAddr = this.normaliseAddress(params.toAddr);
     this.nonce = params.nonce;
     this.pubKey = params.pubKey;
     this.amount = params.amount;
@@ -268,11 +267,11 @@ export class Transaction implements Signable {
 
   private normaliseAddress(address: string) {
     if (validation.isBech32(address)) {
-      return fromBech32Address(address).slice(2);
+      return fromBech32Address(address);
     }
 
-    if (validation.isAddress(address)) {
-      return toChecksumAddress(address.replace('0x', '')).slice(2);
+    if (isValidChecksumAddress(address)) {
+      return address;
     }
 
     throw new Error('Address format is invalid');

--- a/packages/zilliqa-js-account/src/util.ts
+++ b/packages/zilliqa-js-account/src/util.ts
@@ -7,7 +7,8 @@ export const encodeTransactionProto = (tx: TxParams): Buffer => {
   const msg = {
     version: tx.version,
     nonce: tx.nonce || 0,
-    toaddr: bytes.hexToByteArray(tx.toAddr.toLowerCase()),
+    // core protocol Schnorr expects lowercase, non-prefixed address.
+    toaddr: bytes.hexToByteArray(tx.toAddr.replace('0x', '').toLowerCase()),
     senderpubkey: ZilliqaMessage.ByteArray.create({
       data: bytes.hexToByteArray(tx.pubKey || '00'),
     }),

--- a/packages/zilliqa-js-account/src/wallet.ts
+++ b/packages/zilliqa-js-account/src/wallet.ts
@@ -218,7 +218,10 @@ export class Wallet extends Signer {
       const signer = this.accounts[account];
 
       if (!tx.txParams.nonce) {
-        const balance = await this.provider.send('GetBalance', signer.address);
+        const balance = await this.provider.send(
+          'GetBalance',
+          signer.address.replace('0x', '').toLowerCase(),
+        );
 
         if (typeof balance.result.nonce !== 'number') {
           throw new Error('Could not get nonce');

--- a/packages/zilliqa-js-account/test/account.spec.ts
+++ b/packages/zilliqa-js-account/test/account.spec.ts
@@ -14,6 +14,7 @@ describe('Account', () => {
     const keystore = await account.toFile('stronk_password');
 
     const decrypted = await Account.fromFile(keystore, 'stronk_password');
+    expect(decrypted.address).toEqual(account.address);
     expect(decrypted.privateKey).toEqual(account.privateKey);
   });
 

--- a/packages/zilliqa-js-account/test/fixtures/keystores.json
+++ b/packages/zilliqa-js-account/test/fixtures/keystores.json
@@ -1,10 +1,14 @@
 [
   {
+    "privateKey": "cb71f8172af45efa7350c72b55718cb075004e9fb361a7d3ef13f8d5c3baa482",
+    "passphrase": "277281fdeea0e597",
     "keystore": {
-      "address": "9aecb3d2e90b416e2be8280f678139868be55486",
+      "address": "0x9AEcB3D2e90b416e2bE8280F678139868BE55486",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "6975d2ffa4a523492040d744b6ad14b9" },
+        "cipherparams": {
+          "iv": "6975d2ffa4a523492040d744b6ad14b9"
+        },
         "ciphertext": "7a3196eb5e0b001b36003018c3088851d2278d30020da24e07eac6d19dfe3c87",
         "kdf": "scrypt",
         "kdfparams": {
@@ -19,16 +23,18 @@
       },
       "id": "31616335-6236-4166-a663-336231373238",
       "version": 3
-    },
-    "privateKey": "cb71f8172af45efa7350c72b55718cb075004e9fb361a7d3ef13f8d5c3baa482",
-    "passphrase": "277281fdeea0e597"
+    }
   },
   {
+    "privateKey": "78b5a225adf40f32658d9956071afcaf252db568387cb97bbfe5c507276f8d67",
+    "passphrase": "68568e8e9d5e1151",
     "keystore": {
-      "address": "9f40fbff9eda6fcd560e391c06386bc9606aedaa",
+      "address": "0x9F40FBFf9edA6fcd560e391c06386BC9606aeDAa",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "9016298cac601a6a56b0f523ab3e005f" },
+        "cipherparams": {
+          "iv": "9016298cac601a6a56b0f523ab3e005f"
+        },
         "ciphertext": "a004cfa3699327acf87961f134e6dd070adb5fde6bfce0d75c2e90753f590126",
         "kdf": "scrypt",
         "kdfparams": {
@@ -43,16 +49,18 @@
       },
       "id": "30656331-3338-4363-b166-616636373762",
       "version": 3
-    },
-    "privateKey": "78b5a225adf40f32658d9956071afcaf252db568387cb97bbfe5c507276f8d67",
-    "passphrase": "68568e8e9d5e1151"
+    }
   },
   {
+    "privateKey": "ce99c43a81b66c84c09a8d9c7b00af172d7c3003ee5d0dca080709cd843498fb",
+    "passphrase": "b0cb6ce5cd2c5802",
     "keystore": {
-      "address": "e1f7eb9c92dc27748c3e673c35fe44e5bacb33f7",
+      "address": "0xe1f7eB9c92dc27748C3e673C35fe44E5bacb33F7",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "f7bdd5ec1340b52237849f2d55c6c56a" },
+        "cipherparams": {
+          "iv": "f7bdd5ec1340b52237849f2d55c6c56a"
+        },
         "ciphertext": "13366a679b7306f0cb23958b36a3ade67800d6e613aa900f778a78677a9c4a1d",
         "kdf": "scrypt",
         "kdfparams": {
@@ -67,16 +75,18 @@
       },
       "id": "38363431-3030-4830-a431-303564373665",
       "version": 3
-    },
-    "privateKey": "ce99c43a81b66c84c09a8d9c7b00af172d7c3003ee5d0dca080709cd843498fb",
-    "passphrase": "b0cb6ce5cd2c5802"
+    }
   },
   {
+    "privateKey": "f4d47000b2baddcead198f51e6de89a3035af87cb25d65f5005bfa1a0bff497c",
+    "passphrase": "38222f97363835bf",
     "keystore": {
-      "address": "b79ce2630aa1255c47af51e102bae46772090f79",
+      "address": "0xb79CE2630aa1255C47AF51E102BAE46772090F79",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "3f3e0f781aa9616d1a1aa3ddd30a2050" },
+        "cipherparams": {
+          "iv": "3f3e0f781aa9616d1a1aa3ddd30a2050"
+        },
         "ciphertext": "e482889816f10320fa3dd30fa6940e1e159b5f6e10958335c96bc134ad62f1e4",
         "kdf": "scrypt",
         "kdfparams": {
@@ -91,16 +101,18 @@
       },
       "id": "63636532-3438-4134-b334-633930383030",
       "version": 3
-    },
-    "privateKey": "f4d47000b2baddcead198f51e6de89a3035af87cb25d65f5005bfa1a0bff497c",
-    "passphrase": "38222f97363835bf"
+    }
   },
   {
+    "privateKey": "59bab003c6471463001aa76cb9766f8a3dd13ab04c5f21b6ce3323cb7b2858d5",
+    "passphrase": "feea9a68565082c2",
     "keystore": {
-      "address": "7675bcc39a3b4290a5059d4ec925b5bad1ce7d7e",
+      "address": "0x7675BCC39A3B4290A5059D4Ec925B5bAD1Ce7D7E",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "fcf270e966455dc752293b025e40952c" },
+        "cipherparams": {
+          "iv": "fcf270e966455dc752293b025e40952c"
+        },
         "ciphertext": "60fd77dfdde7c8d66a20513577f55eb26064bbfe5cccf1a903d3c0d98430bbb9",
         "kdf": "scrypt",
         "kdfparams": {
@@ -115,16 +127,18 @@
       },
       "id": "32623434-6237-4165-a139-333435386137",
       "version": 3
-    },
-    "privateKey": "59bab003c6471463001aa76cb9766f8a3dd13ab04c5f21b6ce3323cb7b2858d5",
-    "passphrase": "feea9a68565082c2"
+    }
   },
   {
+    "privateKey": "f1092263ed2631867d450a1fea54dab348a88590af3cf35194afb2fb74fec60e",
+    "passphrase": "b8c2d76d90603184",
     "keystore": {
-      "address": "1cf63573ccf4c164d47ad7dd6b3856a3d4115181",
+      "address": "0x1cF63573ccf4c164d47aD7DD6b3856A3D4115181",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "9c357b2376988ec17d20ae5db20fae75" },
+        "cipherparams": {
+          "iv": "9c357b2376988ec17d20ae5db20fae75"
+        },
         "ciphertext": "3c1365cf6ca58a1d1332fef4c276f80918d85d91ffa72602b59d2d07cb9c2b01",
         "kdf": "scrypt",
         "kdfparams": {
@@ -139,16 +153,18 @@
       },
       "id": "33643932-3966-4138-a362-633562656533",
       "version": 3
-    },
-    "privateKey": "f1092263ed2631867d450a1fea54dab348a88590af3cf35194afb2fb74fec60e",
-    "passphrase": "b8c2d76d90603184"
+    }
   },
   {
+    "privateKey": "d8a8e570210d5bd6fd18d4c329c350dcbacd561b370b8f44ea82854be125c9fd",
+    "passphrase": "79aef1be9c21fa6d",
     "keystore": {
-      "address": "b032929fda068344c06390886851b58618e0d371",
+      "address": "0xb032929FdA068344c06390886851B58618E0d371",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "3c8e3afd22737e5a808de1229c1df481" },
+        "cipherparams": {
+          "iv": "3c8e3afd22737e5a808de1229c1df481"
+        },
         "ciphertext": "9f52a8a5d6a7c97fc214c12d38e04fe306af300951cffa84ed28e67d2f1319e5",
         "kdf": "scrypt",
         "kdfparams": {
@@ -163,16 +179,18 @@
       },
       "id": "61663231-3035-4734-b431-636139323461",
       "version": 3
-    },
-    "privateKey": "d8a8e570210d5bd6fd18d4c329c350dcbacd561b370b8f44ea82854be125c9fd",
-    "passphrase": "79aef1be9c21fa6d"
+    }
   },
   {
+    "privateKey": "d839036075bdde6d5e80dbd62224c62015d2134675d0b3a2b952a3946151381f",
+    "passphrase": "74df0c784b9ca723",
     "keystore": {
-      "address": "716b269cc1e16af73ec06c11b56ff4473ffb90c2",
+      "address": "0x716b269cC1E16Af73eC06C11B56fF4473fFb90C2",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "a91eb27262d258fda2b659ba700dbabf" },
+        "cipherparams": {
+          "iv": "a91eb27262d258fda2b659ba700dbabf"
+        },
         "ciphertext": "071a026788102ac115b385ecfa44a94308ae6e9d9bf3195b33afd5011c092883",
         "kdf": "scrypt",
         "kdfparams": {
@@ -187,16 +205,18 @@
       },
       "id": "66313337-6239-4362-b131-336466653837",
       "version": 3
-    },
-    "privateKey": "d839036075bdde6d5e80dbd62224c62015d2134675d0b3a2b952a3946151381f",
-    "passphrase": "74df0c784b9ca723"
+    }
   },
   {
+    "privateKey": "e94de67e79c60ee1db62a7aa505a67135e172156a5abf587150b6cc6eb9b08bb",
+    "passphrase": "cf4b98b6284a54fa",
     "keystore": {
-      "address": "5ac3b3f9ece121588d4b4d8369fd17991e9faa45",
+      "address": "0x5ac3b3F9eCe121588d4B4d8369fd17991e9fAA45",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "c2666e0f3733618a9eaebdebcd954b63" },
+        "cipherparams": {
+          "iv": "c2666e0f3733618a9eaebdebcd954b63"
+        },
         "ciphertext": "021e6c2cd087e60e94d3cd3cb9395883dc469cc371583146ef71c3959d6a22fd",
         "kdf": "scrypt",
         "kdfparams": {
@@ -211,16 +231,18 @@
       },
       "id": "33356632-6136-4362-b939-356137313065",
       "version": 3
-    },
-    "privateKey": "e94de67e79c60ee1db62a7aa505a67135e172156a5abf587150b6cc6eb9b08bb",
-    "passphrase": "cf4b98b6284a54fa"
+    }
   },
   {
+    "privateKey": "268a3c5292823e497bd25aea381e22688bff45c47676d8890cf33b8daebf09a6",
+    "passphrase": "09069a0662a617b0",
     "keystore": {
-      "address": "939dc05470c4a14da675393238c6f8cee5a175e9",
+      "address": "0x939dC05470c4a14dA675393238C6f8CEe5A175e9",
       "crypto": {
         "cipher": "aes-128-ctr",
-        "cipherparams": { "iv": "c9cceb96cd2c5438d443715fec7c79a0" },
+        "cipherparams": {
+          "iv": "c9cceb96cd2c5438d443715fec7c79a0"
+        },
         "ciphertext": "34d308a6cebb01e7558832ee18e394b320d180d2b80387cafc950bcd080121c0",
         "kdf": "scrypt",
         "kdfparams": {
@@ -235,8 +257,6 @@
       },
       "id": "61623230-3232-4430-a262-333930316261",
       "version": 3
-    },
-    "privateKey": "268a3c5292823e497bd25aea381e22688bff45c47676d8890cf33b8daebf09a6",
-    "passphrase": "09069a0662a617b0"
+    }
   }
 ]

--- a/packages/zilliqa-js-account/test/transaction.spec.ts
+++ b/packages/zilliqa-js-account/test/transaction.spec.ts
@@ -15,6 +15,8 @@ import fetch from 'jest-fetch-mock';
 const provider = new HTTPProvider('https://mock.com');
 const wallet = new Wallet(provider);
 
+const generateChecksumAddress = () => toChecksumAddress(randomBytes(20));
+
 describe('Transaction', () => {
   for (let i = 0; i < 10; i++) {
     wallet.create();
@@ -28,7 +30,7 @@ describe('Transaction', () => {
     const tx = new Transaction(
       {
         version: 0,
-        toAddr: `0x${randomBytes(20)}`,
+        toAddr: generateChecksumAddress(),
         amount: new BN(0),
         gasPrice: new BN(1000),
         gasLimit: Long.fromNumber(1000),
@@ -37,7 +39,7 @@ describe('Transaction', () => {
     );
 
     // FIXME: remove 0x when this is fixed on the core side
-    expect(isValidChecksumAddress(`0x${tx.txParams.toAddr}`)).toBe(true);
+    expect(isValidChecksumAddress(tx.txParams.toAddr)).toBe(true);
   });
 
   it('should accept bech32 toAddr', () => {
@@ -55,9 +57,8 @@ describe('Transaction', () => {
       provider,
     );
 
-    // FIXME: remove 0x when this is fixed on the core side
-    expect(isValidChecksumAddress(`0x${tx.txParams.toAddr}`)).toBe(true);
-    expect(`0x${tx.txParams.toAddr}`).toEqual(b16);
+    expect(isValidChecksumAddress(tx.txParams.toAddr)).toBe(true);
+    expect(tx.txParams.toAddr).toEqual(b16);
   });
 
   it('should poll and call queued handlers on confirmation', async () => {

--- a/packages/zilliqa-js-account/test/transactionFactory.spec.ts
+++ b/packages/zilliqa-js-account/test/transactionFactory.spec.ts
@@ -11,15 +11,55 @@ const transactionFactory = new TransactionFactory(provider, wallet);
 
 describe('TransactionFactory', () => {
   it('should be able to create a fresh tx', () => {
-    const tx = transactionFactory.new({
+    const txb16 = transactionFactory.new({
       version: 0,
       amount: new BN(0),
       gasPrice: new BN(1),
       gasLimit: Long.fromNumber(100),
-      toAddr: '0x88888888888888888888',
+      toAddr: '0x4BAF5faDA8e5Db92C3d3242618c5B47133AE003C',
     });
 
-    expect(tx).toBeInstanceOf(Transaction);
-    expect(tx.isInitialised()).toBeTruthy();
+    const txb32 = transactionFactory.new({
+      version: 0,
+      amount: new BN(0),
+      gasPrice: new BN(1),
+      gasLimit: Long.fromNumber(100),
+      toAddr: '0x4BAF5faDA8e5Db92C3d3242618c5B47133AE003C',
+    });
+
+    expect(txb16).toBeInstanceOf(Transaction);
+    expect(txb32).toBeInstanceOf(Transaction);
+
+    expect(txb16.isInitialised()).toBeTruthy();
+    expect(txb32.isInitialised()).toBeTruthy();
+  });
+
+  it('should throw if toAddr is an invalid checksum address', () => {
+    const createTx = () => {
+      return transactionFactory.new({
+        version: 0,
+        amount: new BN(0),
+        gasPrice: new BN(1),
+        gasLimit: Long.fromNumber(100),
+        toAddr: '0x4bAf5fada8E5dB92C3D3242618C5b47133ae003c',
+      });
+    };
+
+    expect(createTx).toThrowError();
+  });
+
+  it('should throw if toAddr is an invalid bech32 address', () => {
+    const createTx = () => {
+      return transactionFactory.new({
+        version: 0,
+        amount: new BN(0),
+        gasPrice: new BN(1),
+        gasLimit: Long.fromNumber(100),
+        toAddr:
+          'an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx',
+      });
+    };
+
+    expect(createTx).toThrowError();
   });
 });

--- a/packages/zilliqa-js-account/test/wallet.spec.ts
+++ b/packages/zilliqa-js-account/test/wallet.spec.ts
@@ -38,16 +38,16 @@ describe('Wallet', () => {
     expect(Object.keys(wallet.accounts).length).toEqual(10);
     expect(Object.keys(wallet.accounts).sort()).toEqual(addresses.sort());
     expect(Object.keys(wallet.accounts).sort()).toEqual([
-      "0237f40d30d3c37c9b77577acbb11c972cc58664", 
-      "0723dd96243491ee84a925edb657f24582aec899", 
-      "4878d8eb9a63493a6de066eb1458cab672dc8cfd", 
-      "68275607e8bdf7cfa248b5f5a07b576f9ef39cd1", 
-      "852f52532c3c928269bdd3b83ac88e25a04d6b3b", 
-      "9165ae9ceeb155fb75d9c1fee2041f12c6e1f5ea", 
-      "aacdf9c84bba51878c8681c72f035b62135d6d7e", 
-      "bea456fb58094be1c7f99bb6d1584dcec642b0b0", 
-      "cd6cb5bc8f3ee8ff7a91b060ce341feb6fc40e21", 
-      "ecd9d875c7366432a7ce403a7702dfa3e7f09602"
+      '0x0237F40D30d3c37C9b77577ACbB11C972Cc58664',
+      '0x0723DD96243491eE84A925eDB657f24582AEc899',
+      '0x4878d8EB9A63493A6de066eB1458CaB672Dc8CfD',
+      '0x68275607E8bDf7cFA248b5f5a07B576F9Ef39cD1',
+      '0x852F52532c3c928269bdd3B83Ac88E25A04D6B3b',
+      '0x9165AE9ceeb155fB75D9C1fee2041f12C6e1f5eA',
+      '0xAACDF9c84Bba51878C8681C72f035B62135d6d7e',
+      '0xCd6cb5bC8F3EE8fF7a91B060Ce341FEb6Fc40E21',
+      '0xEcD9D875C7366432a7Ce403A7702dFa3e7F09602',
+      '0xbEA456Fb58094Be1C7f99BB6D1584DCEc642B0B0',
     ]);
   });
 

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -240,13 +240,13 @@ export class Blockchain implements ZilliqaModule {
    * createTransaction
    *
    * Creates a transaction and polls the lookup node for a transaction
-   * receipt. The transaction is considered to be lost if it is not confirmed 
+   * receipt. The transaction is considered to be lost if it is not confirmed
    * within the timeout period.
    *
    * @param {Transaction} tx
    * @param {number} maxAttempts - (optional) number of times to poll before timing out
    * @param {number} number - (optional) interval in ms
-   * @returns {Promise<Transaction>} - the Transaction that has been signed and 
+   * @returns {Promise<Transaction>} - the Transaction that has been signed and
    * broadcasted to the network.
    */
   @sign
@@ -373,7 +373,10 @@ export class Blockchain implements ZilliqaModule {
    * @returns {Promise<RPCResponse<any, string>>}
    */
   getBalance(address: string): Promise<RPCResponse<any, string>> {
-    return this.provider.send(RPCMethod.GetBalance, address);
+    return this.provider.send(
+      RPCMethod.GetBalance,
+      address.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**

--- a/packages/zilliqa-js-blockchain/test/chain.ispec.ts
+++ b/packages/zilliqa-js-blockchain/test/chain.ispec.ts
@@ -5,6 +5,7 @@ import {
   TxBlockObj,
   BlockList,
 } from '@zilliqa-js/core';
+import { toChecksumAddress } from '@zilliqa-js/crypto';
 import { BN, Long, bytes } from '@zilliqa-js/util';
 
 import { Blockchain } from '../src/chain';
@@ -101,7 +102,8 @@ describe('[Integration]: Blockchain', () => {
 
   it('should be able to get a list of TxBlocks', async () => {
     const { result } = await bc.getNumTxBlocks();
-    const numTxBlocks = parseInt(<string>result, 10);
+    // mod reduce because there are way too many blocks
+    const numTxBlocks = parseInt(<string>result, 10) % 888;
 
     if (numTxBlocks > 10) {
       const numPages =
@@ -120,7 +122,7 @@ describe('[Integration]: Blockchain', () => {
       }, 0);
 
       expect(resolved.length).toEqual(numPages);
-      expect(receivedNumTxBlocks).toEqual(numTxBlocks);
+      expect(receivedNumTxBlocks).toEqual(numPages * 10);
     } else {
       const response = await bc.getTxBlockListing(1);
       expect((<BlockList>response.result).data.length).toEqual(numTxBlocks);
@@ -151,7 +153,7 @@ describe('[Integration]: Blockchain', () => {
     const transaction = new Transaction(
       {
         version: bytes.pack(CHAIN_ID, 1),
-        toAddr: 'd11238e5fcd70c817c22922c500830d00bc1e778',
+        toAddr: toChecksumAddress('d11238e5fcd70c817c22922c500830d00bc1e778'),
         amount: new BN(888),
         gasPrice: new BN(1000000000),
         gasLimit: Long.fromNumber(1),

--- a/packages/zilliqa-js-contract/src/contract.ts
+++ b/packages/zilliqa-js-contract/src/contract.ts
@@ -15,7 +15,7 @@ import {
   DeployParams,
 } from './types';
 
-const NIL_ADDRESS = '0000000000000000000000000000000000000000';
+const NIL_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export class Contract {
   factory: Contracts;

--- a/packages/zilliqa-js-contract/src/contract.ts
+++ b/packages/zilliqa-js-contract/src/contract.ts
@@ -205,9 +205,13 @@ export class Contract {
       return Promise.resolve([]);
     }
 
+    if (!this.address) {
+      throw new Error('Cannot get state of uninitialised contract');
+    }
+
     const response = await this.provider.send(
       'GetSmartContractState',
-      this.address,
+      this.address.replace('0x', '').toLowerCase(),
     );
 
     return response.result;
@@ -218,9 +222,13 @@ export class Contract {
       return Promise.resolve([]);
     }
 
+    if (!this.address) {
+      throw new Error('Cannot get state of uninitialised contract');
+    }
+
     const response = await this.provider.send(
       'GetSmartContractInit',
-      this.address,
+      this.address.replace('0x', '').toLowerCase(),
     );
 
     return response.result;

--- a/packages/zilliqa-js-contract/src/factory.ts
+++ b/packages/zilliqa-js-contract/src/factory.ts
@@ -1,6 +1,7 @@
 import hash from 'hash.js';
 
 import { Wallet, Transaction, util } from '@zilliqa-js/account';
+import { toChecksumAddress } from '@zilliqa-js/crypto';
 import { Provider, RPCMethod, ZilliqaModule } from '@zilliqa-js/core';
 import { bytes } from '@zilliqa-js/util';
 
@@ -28,12 +29,14 @@ export class Contracts implements ZilliqaModule {
     // based on the nonce in the global state.
     const nonce = tx.txParams.nonce ? tx.txParams.nonce - 1 : 0;
 
-    return hash
-      .sha256()
-      .update(tx.senderAddress, 'hex')
-      .update(bytes.intToHexArray(nonce, 16).join(''), 'hex')
-      .digest('hex')
-      .slice(24);
+    return toChecksumAddress(
+      hash
+        .sha256()
+        .update(tx.senderAddress, 'hex')
+        .update(bytes.intToHexArray(nonce, 16).join(''), 'hex')
+        .digest('hex')
+        .slice(24),
+    );
   }
 
   provider: Provider;

--- a/packages/zilliqa-js-contract/src/factory.ts
+++ b/packages/zilliqa-js-contract/src/factory.ts
@@ -32,7 +32,7 @@ export class Contracts implements ZilliqaModule {
     return toChecksumAddress(
       hash
         .sha256()
-        .update(tx.senderAddress, 'hex')
+        .update(tx.senderAddress.replace('0x', '').toLowerCase(), 'hex')
         .update(bytes.intToHexArray(nonce, 16).join(''), 'hex')
         .digest('hex')
         .slice(24),

--- a/packages/zilliqa-js-contract/test/contract.ispec.ts
+++ b/packages/zilliqa-js-contract/test/contract.ispec.ts
@@ -1,6 +1,7 @@
 import { Account, Transaction, Wallet } from '@zilliqa-js/account';
 import { Blockchain } from '@zilliqa-js/blockchain';
 import { HTTPProvider } from '@zilliqa-js/core';
+import { toChecksumAddress } from '@zilliqa-js/crypto';
 import { BN, Long, bytes, units } from '@zilliqa-js/util';
 import { Contracts, Contract, ContractStatus, Value } from '../src/index';
 import { testContract, zrc20, simpleDEX as dex, touchAndPay } from './fixtures';
@@ -49,7 +50,9 @@ describe('Contract: touch and pay', () => {
           new Transaction(
             {
               version: bytes.pack(CHAIN_ID, 1),
-              toAddr: 'd11238e5fcd70c817c22922c500830d00bc1e778',
+              toAddr: toChecksumAddress(
+                'd11238e5fcd70c817c22922c500830d00bc1e778',
+              ),
               amount: new BN(888),
               gasPrice: new BN(1000000000),
               gasLimit: Long.fromNumber(1),
@@ -77,7 +80,7 @@ describe('Contract: hello world', () => {
         {
           vname: 'owner',
           type: 'ByStr20',
-          value: `0x${process.env.GENESIS_ADDRESS}`,
+          value: process.env.GENESIS_ADDRESS as string,
         },
         {
           vname: '_scilla_version',
@@ -96,6 +99,7 @@ describe('Contract: hello world', () => {
       );
 
     address = <string>contract.address;
+    console.log(`Hello world address: ${address}`);
 
     expect(tx.isConfirmed()).toBeTruthy();
     expect(contract.status).toEqual(ContractStatus.Deployed);
@@ -137,7 +141,7 @@ describe('Contract: hello world', () => {
 
   it('should be rejected by the server if a non-existent contract is called', async () => {
     // setup a non-existent address
-    const contract = contractFactory.at('0123456789'.repeat(4));
+    const contract = contractFactory.at(`0x${'0123456789'.repeat(4)}`);
     const call = await contract.call(
       'setHello',
       [
@@ -233,7 +237,7 @@ describe('Contract: Simple DEX', () => {
           {
             vname: 'owner',
             type: 'ByStr20',
-            value: `0x${token1Owner.address}`,
+            value: token1Owner.address,
           },
           { vname: 'total_tokens', type: 'Uint128', value: '888888888888888' },
         ])
@@ -249,7 +253,7 @@ describe('Contract: Simple DEX', () => {
           {
             vname: 'owner',
             type: 'ByStr20',
-            value: `0x${token2Owner.address}`,
+            value: token2Owner.address,
           },
           { vname: 'total_tokens', type: 'Uint128', value: '888888888888888' },
         ])
@@ -265,7 +269,7 @@ describe('Contract: Simple DEX', () => {
           {
             vname: 'contractOwner',
             type: 'ByStr20',
-            value: `0x${simpleDexOwner.address}`,
+            value: simpleDexOwner.address,
           },
         ])
         .deploy({
@@ -294,7 +298,7 @@ describe('Contract: Simple DEX', () => {
       token1.call(
         'Transfer',
         [
-          { vname: 'to', type: 'ByStr20', value: `0x${token1Holder.address}` },
+          { vname: 'to', type: 'ByStr20', value: token1Holder.address },
           { vname: 'tokens', type: 'Uint128', value: '888' },
         ],
         {
@@ -308,7 +312,7 @@ describe('Contract: Simple DEX', () => {
       token2.call(
         'Transfer',
         [
-          { vname: 'to', type: 'ByStr20', value: `0x${token2Holder.address}` },
+          { vname: 'to', type: 'ByStr20', value: token2Holder.address },
           { vname: 'tokens', type: 'Uint128', value: '888' },
         ],
         {
@@ -342,7 +346,7 @@ describe('Contract: Simple DEX', () => {
           {
             vname: 'spender',
             type: 'ByStr20',
-            value: `0x${simpleDEX.address}`,
+            value: simpleDEX.address as string,
           },
           {
             vname: 'tokens',
@@ -364,7 +368,7 @@ describe('Contract: Simple DEX', () => {
           {
             vname: 'spender',
             type: 'ByStr20',
-            value: `0x${simpleDEX.address}`,
+            value: simpleDEX.address as string,
           },
           {
             vname: 'tokens',
@@ -410,7 +414,7 @@ describe('Contract: Simple DEX', () => {
         {
           vname: 'tokenA',
           type: 'ByStr20',
-          value: `0x${token1.address}`,
+          value: token1.address as string,
         },
         {
           vname: 'valueA',
@@ -420,7 +424,7 @@ describe('Contract: Simple DEX', () => {
         {
           vname: 'tokenB',
           type: 'ByStr20',
-          value: `0x${token2.address}`,
+          value: token2.address as string,
         },
         {
           vname: 'valueB',
@@ -600,7 +604,7 @@ describe('Contract: HWGC', async () => {
           // NOTE: all byte strings passed to Scilla contracts _must_ be
           // prefixed with 0x. Failure to do so will result in the network
           // rejecting the transaction while consuming gas!
-          value: `0x${process.env.GENESIS_ADDRESS}`,
+          value: process.env.GENESIS_ADDRESS as string,
         },
       ];
 
@@ -653,7 +657,6 @@ describe('Contract: HWGC', async () => {
       // Get the deployed contract address
       console.log('2nd contract address is:');
       console.log(chainchain2.address);
-      const cadd2 = `0x${chainchain2.address}`;
 
       // Instance of class Contract 3
       const contract3 = contractFactory.new(code3, init);
@@ -678,7 +681,6 @@ describe('Contract: HWGC', async () => {
       // Get the deployed contract address
       console.log('3rd contract address is:');
       console.log(chainchain3.address);
-      const cadd3 = `0x${chainchain3.address}`;
 
       // setAdd in contract 1 for contract 2
       const callTx1 = await chainchain1.call(
@@ -687,7 +689,7 @@ describe('Contract: HWGC', async () => {
           {
             vname: 'currentContractAdd',
             type: 'ByStr20',
-            value: cadd2,
+            value: chainchain2.address as string,
           },
         ],
         {
@@ -721,7 +723,7 @@ describe('Contract: HWGC', async () => {
           {
             vname: 'currentContractAdd',
             type: 'ByStr20',
-            value: cadd3,
+            value: chainchain3.address as string,
           },
         ],
         {

--- a/packages/zilliqa-js-contract/test/contract.spec.ts
+++ b/packages/zilliqa-js-contract/test/contract.spec.ts
@@ -323,6 +323,8 @@ describe('Contracts', () => {
         jsonrpc: '2.0',
         result: {
           ID: 'some_hash',
+          senderPubKey:
+            '0314738163B9BB67AD11AA464FE69A1147DF263E8970D7DCFD8F993DDD39E81BD9',
           receipt: {
             success: true,
             cumulative_gas: 1000,
@@ -349,6 +351,8 @@ describe('Contracts', () => {
         jsonrpc: '2.0',
         result: {
           ID: 'some_hash',
+          senderPubKey:
+            '0314738163B9BB67AD11AA464FE69A1147DF263E8970D7DCFD8F993DDD39E81BD9',
           receipt: {
             success: true,
             cumulative_gas: 1000,

--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -18,11 +18,13 @@ export const getAddressFromPrivateKey = (privateKey: string): string => {
   const keyPair = secp256k1.keyFromPrivate(privateKey, 'hex');
   const pub = keyPair.getPublic(true, 'hex');
 
-  return hashjs
-    .sha256()
-    .update(pub, 'hex')
-    .digest('hex')
-    .slice(24);
+  return toChecksumAddress(
+    hashjs
+      .sha256()
+      .update(pub, 'hex')
+      .digest('hex')
+      .slice(24),
+  );
 };
 
 /**
@@ -59,11 +61,13 @@ export const compressPublicKey = (publicKey: string): string => {
  * @returns {string}
  */
 export const getAddressFromPublicKey = (publicKey: string) => {
-  return hashjs
-    .sha256()
-    .update(publicKey, 'hex')
-    .digest('hex')
-    .slice(24);
+  return toChecksumAddress(
+    hashjs
+      .sha256()
+      .update(publicKey, 'hex')
+      .digest('hex')
+      .slice(24),
+  );
 };
 
 /**

--- a/packages/zilliqa-js-crypto/test/address.spec.ts
+++ b/packages/zilliqa-js-crypto/test/address.spec.ts
@@ -9,10 +9,11 @@ describe('addresses', () => {
       const generatedPub = crypto.getPubKeyFromPrivateKey(priv);
       const addressFromPriv = crypto.getAddressFromPrivateKey(priv);
       const addressFromPub = crypto.getAddressFromPrivateKey(priv);
+      const checksummedAddress = crypto.toChecksumAddress(address);
 
       expect(generatedPub.toUpperCase()).toEqual(pub);
-      expect(addressFromPriv.toUpperCase()).toEqual(address);
-      expect(addressFromPub.toUpperCase()).toEqual(address);
+      expect(addressFromPriv).toEqual(checksummedAddress);
+      expect(addressFromPub).toEqual(checksummedAddress);
     });
   });
 

--- a/packages/zilliqa-js-crypto/test/keys.spec.ts
+++ b/packages/zilliqa-js-crypto/test/keys.spec.ts
@@ -18,10 +18,10 @@ describe('keypairs', () => {
 
   it('should convert a public key to an address', () => {
     pairs.forEach(({ public: pub, digest }) => {
-      const expected = digest.slice(24);
+      const expected = crypto.toChecksumAddress(digest.slice(24));
       const actual = crypto.getAddressFromPublicKey(pub);
 
-      expect(actual).toHaveLength(40);
+      expect(actual).toHaveLength(42);
       expect(actual).toEqual(expected);
     });
   });
@@ -33,7 +33,7 @@ describe('keypairs', () => {
     );
     const actual = crypto.getAddressFromPrivateKey(pair.private);
 
-    expect(actual).toHaveLength(40);
+    expect(actual).toHaveLength(42);
     expect(actual).toEqual(expected);
   });
 
@@ -44,8 +44,8 @@ describe('keypairs', () => {
         crypto.compressPublicKey(pub),
       );
 
-      expect(fromPrivateKey).toHaveLength(40);
-      expect(fromPublicKey).toHaveLength(40);
+      expect(fromPrivateKey).toHaveLength(42);
+      expect(fromPublicKey).toHaveLength(42);
       expect(fromPublicKey).toEqual(fromPrivateKey);
     });
   });


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR is related to #120, where the new `bech32` address format was added. This diff goes one step further by ensuring that any transaction-creating logic is always forced to use a `toAddr` that is either:

i) valid bech32
ii) valid Zilliqa checksum

The purpose of doing this is to make sure all wallets, explorers, and dApps prevent users from sending transactions of native ZIL to Ethereum addresses leading to irrecoverable loss. Other SDKs should use this as an reference implementation, **icluding all relevant unit tests.**

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

