### PR TITLE
fix(chain): fix getTransaction failing to construct a Transaction object

### DIFF
--- a/packages/zilliqa-js-blockchain/package.json
+++ b/packages/zilliqa-js-blockchain/package.json
@@ -22,6 +22,7 @@
     "@zilliqa-js/account": "0.6.2",
     "@zilliqa-js/contract": "0.6.2",
     "@zilliqa-js/core": "0.6.2",
+    "@zilliqa-js/crypto": "0.6.2",
     "@zilliqa-js/util": "0.6.0",
     "utility-types": "^3.4.1"
   }

--- a/packages/zilliqa-js-blockchain/src/util.ts
+++ b/packages/zilliqa-js-blockchain/src/util.ts
@@ -1,5 +1,6 @@
 import { TxParams } from '@zilliqa-js/account';
 import { RPCResponse, TransactionObj } from '@zilliqa-js/core';
+import { toChecksumAddress } from '@zilliqa-js/crypto';
 import { BN, Long } from '@zilliqa-js/util';
 
 export function toTxParams(
@@ -20,7 +21,7 @@ export function toTxParams(
   return {
     ...rest,
     version: parseInt(version, 10),
-    toAddr,
+    toAddr: toChecksumAddress(toAddr),
     pubKey: senderPubKey,
     gasPrice: new BN(gasPrice),
     gasLimit: Long.fromString(gasLimit, 10),

--- a/packages/zilliqa-js-blockchain/test/util.spec.ts
+++ b/packages/zilliqa-js-blockchain/test/util.spec.ts
@@ -1,0 +1,33 @@
+import { toTxParams } from '../src/util';
+
+describe('blockchain utils', () => {
+  it('toTxParams should handle non-checksummed response from RPC', () => {
+    const address = '1a90c25307c3cc71958a83fa213a2362d859cf33';
+    const mockResponse = {
+      id: 1,
+      jsonrpc: '2.0',
+      error: undefined,
+      result: {
+        ID: '',
+        signature: '',
+        toAddr: address,
+        senderPubKey:
+          '034c39363529c2d4078f72b8c498c4cbc5ba5e10d8666fe06f104a27e0e44242a0',
+        gasPrice: '1000000000',
+        gasLimit: '1',
+        nonce: '8',
+        amount: '1000000000000',
+        receipt: {
+          cumulative_gas: '1000',
+          success: true,
+          event_logs: [],
+          errors: {},
+        },
+        version: '65537',
+      },
+    };
+
+    // @ts-ignore
+    expect(toTxParams(mockResponse));
+  });
+});

--- a/packages/zilliqa-js-blockchain/test/util.spec.ts
+++ b/packages/zilliqa-js-blockchain/test/util.spec.ts
@@ -1,3 +1,4 @@
+import { Transaction } from '@zilliqa-js/account';
 import { toTxParams } from '../src/util';
 
 describe('blockchain utils', () => {
@@ -28,6 +29,6 @@ describe('blockchain utils', () => {
     };
 
     // @ts-ignore
-    expect(toTxParams(mockResponse));
+    expect(() => new Transaction(toTxParams(mockResponse))).not.toThrow();
   });
 });


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This fixes an issue where calls to `zilliqa.blockchain.getTransaction(...)` were failing as transactions cannot be constructed with non-checksummed addresses (returned from the RPC API).

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

