### PR TITLE
Feature/utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,17 @@ a `semver` bump before being able to take advantage of new features/bug fixes.
 
 ```javascript
 const { Transaction } = require('@zilliqa-js/account');
-const { BN, Long, bytes, units } = require('@zilliqa-js/util');
+const { BN, Long, bytes, units, PRESETS } = require('@zilliqa-js/util');
 const { Zilliqa } = require('@zilliqa-js/zilliqa');
 const CP = require ('@zilliqa-js/crypto');
 
-const zilliqa = new Zilliqa('https://dev-api.zilliqa.com');
+const zilliqa = new Zilliqa(PRESETS.DEVNET_URL);
 
 // These are set by the core protocol, and may vary per-chain.
-// These numbers are JUST AN EXAMPLE. They will NOT WORK on the developer testnet
-// or mainnet.
+// You can choose to use the preset according to this example; 
+// or you can manually pack the bytes according to chain id and msg version.
 // For more information: https://apidocs.zilliqa.com/?shell#getnetworkid
-const CHAIN_ID = 2;
-const MSG_VERSION = 1;
-const VERSION = bytes.pack(CHAIN_ID, MSG_VERSION);
+const VERSION = PRESETS.DEVNET_VERSION;
 
 // Populate the wallet with an account
 const privkey = '3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8';

--- a/packages/zilliqa-js-util/README.md
+++ b/packages/zilliqa-js-util/README.md
@@ -15,6 +15,10 @@ See documentation at [long.js](https://github.com/dcodeIO/long.js). This is
 simply a re-export for similar reasons. Note that `long` is only required if
 you need to serialise integers with size greater than or equal to `2^53`.
 
+### `PRESETS`
+
+Commonly used variables such as DEVNET_URL. See [source](./src/presets.ts) for more info.
+
 ## Functions
 
 ### `intToHexArray(int: number, size: number): string[]`

--- a/packages/zilliqa-js-util/src/index.ts
+++ b/packages/zilliqa-js-util/src/index.ts
@@ -16,7 +16,8 @@
 import * as bytes from './bytes';
 import * as validation from './validation';
 import * as units from './unit';
+import { PRESETS } from './presets';
 import BN from 'bn.js';
 import Long from 'long';
 
-export { BN, bytes, Long, units, validation };
+export { BN, bytes, Long, units, validation, PRESETS };

--- a/packages/zilliqa-js-util/src/presets.ts
+++ b/packages/zilliqa-js-util/src/presets.ts
@@ -1,13 +1,22 @@
-export const enum PRESETS {
-  DEVNET_URL = 'https://dev-api.zilliqa.com',
-  DEVNET_CHAIN_ID = 333,
+export interface ZilPreset {
+  DEVNET_URL: string;
+  DEVNET_CHAIN_ID: number;
+  DEVNET_VERSION: number;
+  MAINNET_URL: string;
+  MAINNET_VERSION: number;
+  MSG_VERSION: number;
+}
+
+export const PRESETS: ZilPreset = Object.freeze({
+  DEVNET_URL: 'https://dev-api.zilliqa.com',
+  DEVNET_CHAIN_ID: 333,
   // byte-packed version used for payload versioning
   // DEVNET = bytes.pack(333,1)
-  DEVNET_VERSION = 21823489,
-  MAINNET_URL = 'https://api.zilliqa.com',
-  MAINNET_CHAIN_ID = 1,
+  DEVNET_VERSION: 21823489,
+  MAINNET_URL: 'https://api.zilliqa.com',
+  MAINNET_CHAIN_ID: 1,
   // byte-packed version used for payload versioning
   // MAINNET_VERSION = bytes.pack(1,1)
-  MAINNET_VERSION = 65537,
-  MSG_VERSION = 1,
-}
+  MAINNET_VERSION: 65537,
+  MSG_VERSION: 1,
+});

--- a/packages/zilliqa-js-util/src/presets.ts
+++ b/packages/zilliqa-js-util/src/presets.ts
@@ -1,0 +1,13 @@
+export const enum PRESETS {
+  DEVNET_URL = 'https://dev-api.zilliqa.com',
+  DEVNET_CHAIN_ID = 333,
+  // byte-packed version used for payload versioning
+  // DEVNET = bytes.pack(333,1)
+  DEVNET_VERSION = 21823489,
+  MAINNET_URL = 'https://api.zilliqa.com',
+  MAINNET_CHAIN_ID = 1,
+  // byte-packed version used for payload versioning
+  // MAINNET_VERSION = bytes.pack(1,1)
+  MAINNET_VERSION = 65537,
+  MSG_VERSION = 1,
+}


### PR DESCRIPTION
## Description
Change to Object.freeze as enum does not work for es5. Babel does not work for `const enum`. 
https://babeljs.io/docs/en/babel-plugin-transform-typescript 

@neeboo 
