### PR TITLE
More support for bech32 formats

### DIFF
--- a/packages/zilliqa-js-account/src/account.ts
+++ b/packages/zilliqa-js-account/src/account.ts
@@ -40,11 +40,13 @@ export class Account {
   privateKey: string;
   publicKey: string;
   address: string;
+  bech32Address: string;
 
   constructor(privateKey: string) {
     this.privateKey = privateKey;
     this.publicKey = zcrypto.getPubKeyFromPrivateKey(this.privateKey);
     this.address = zcrypto.getAddressFromPublicKey(this.publicKey);
+    this.bech32Address = zcrypto.toBech32Address(this.address);
   }
 
   /**

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -14,6 +14,8 @@
 //   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Transaction, Wallet, util } from '@zilliqa-js/account';
+import { fromBech32Address } from '@zilliqa-js/crypto';
+import { validation } from '@zilliqa-js/util';
 import { ContractObj, Value } from '@zilliqa-js/contract';
 import {
   GET_TX_ATTEMPTS,
@@ -390,7 +392,8 @@ export class Blockchain implements ZilliqaModule {
    * @param {string} address
    * @returns {Promise<RPCResponse<any, string>>}
    */
-  getBalance(address: string): Promise<RPCResponse<any, string>> {
+  getBalance(addr: string): Promise<RPCResponse<any, string>> {
+    const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetBalance,
       address.replace('0x', '').toLowerCase(),
@@ -404,8 +407,9 @@ export class Blockchain implements ZilliqaModule {
    * @returns {Promise<RPCResponse< code: string }, string>>}
    */
   getSmartContractCode(
-    address: string,
+    addr: string,
   ): Promise<RPCResponse<{ code: string }, string>> {
+    const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContractCode,
       address.replace('0x', '').toLowerCase(),
@@ -418,7 +422,8 @@ export class Blockchain implements ZilliqaModule {
    * @param {string} address
    * @returns {Promise<RPCResponse<Value[], string>>}
    */
-  getSmartContractInit(address: string): Promise<RPCResponse<Value[], string>> {
+  getSmartContractInit(addr: string): Promise<RPCResponse<Value[], string>> {
+    const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContractInit,
       address.replace('0x', '').toLowerCase(),
@@ -431,9 +436,8 @@ export class Blockchain implements ZilliqaModule {
    * @param {string} address
    * @returns {Promise<RPCResponse<Value[], string>>}
    */
-  getSmartContractState(
-    address: string,
-  ): Promise<RPCResponse<Value[], string>> {
+  getSmartContractState(addr: string): Promise<RPCResponse<Value[], string>> {
+    const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContractState,
       address.replace('0x', '').toLowerCase(),
@@ -447,8 +451,9 @@ export class Blockchain implements ZilliqaModule {
    * @returns {Promise<RPCResponse<Omit<ContractObj, 'init' | 'abi'>, string>>}
    */
   getSmartContracts(
-    address: string,
+    addr: string,
   ): Promise<RPCResponse<Omit<ContractObj, 'init' | 'abi'>, string>> {
+    const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContracts,
       address.replace('0x', '').toLowerCase(),

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -406,7 +406,10 @@ export class Blockchain implements ZilliqaModule {
   getSmartContractCode(
     address: string,
   ): Promise<RPCResponse<{ code: string }, string>> {
-    return this.provider.send(RPCMethod.GetSmartContractCode, address);
+    return this.provider.send(
+      RPCMethod.GetSmartContractCode,
+      address.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**
@@ -416,7 +419,10 @@ export class Blockchain implements ZilliqaModule {
    * @returns {Promise<RPCResponse<Value[], string>>}
    */
   getSmartContractInit(address: string): Promise<RPCResponse<Value[], string>> {
-    return this.provider.send(RPCMethod.GetSmartContractInit, address);
+    return this.provider.send(
+      RPCMethod.GetSmartContractInit,
+      address.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**
@@ -428,7 +434,10 @@ export class Blockchain implements ZilliqaModule {
   getSmartContractState(
     address: string,
   ): Promise<RPCResponse<Value[], string>> {
-    return this.provider.send(RPCMethod.GetSmartContractState, address);
+    return this.provider.send(
+      RPCMethod.GetSmartContractState,
+      address.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**
@@ -440,7 +449,10 @@ export class Blockchain implements ZilliqaModule {
   getSmartContracts(
     address: string,
   ): Promise<RPCResponse<Omit<ContractObj, 'init' | 'abi'>, string>> {
-    return this.provider.send(RPCMethod.GetSmartContracts, address);
+    return this.provider.send(
+      RPCMethod.GetSmartContracts,
+      address.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Addresses can be really confusing for a developer. It can come in ByStr20 or `bech32` format. If it comes in `ByStr20`, it might or might not come with a `0x` prefix.

This PR adds the following:
- Strips `0x` before sending to RPC
- Converts `bech32` to `ByStr20` before sending to the RPC
- Added `bech32` to Account object

Fixes #148 and #149 
CC: @neeboo