### PR TITLE
feat(core): added eventEmitter to core and make transaction events em…

### DIFF
--- a/packages/zilliqa-js-account/src/transaction.ts
+++ b/packages/zilliqa-js-account/src/transaction.ts
@@ -217,16 +217,6 @@ export class Transaction implements Signable {
   }
 
   observed(): EventEmitter<Transaction> {
-    try {
-      if (this.eventEmitter.resolve) {
-        this.eventEmitter.resolve(this);
-      }
-    } catch (error) {
-      if (this.eventEmitter.reject) {
-        this.eventEmitter.reject(error);
-      }
-      throw error;
-    }
     return this.eventEmitter;
   }
   /**

--- a/packages/zilliqa-js-account/src/transaction.ts
+++ b/packages/zilliqa-js-account/src/transaction.ts
@@ -20,11 +20,19 @@ import {
   Signable,
   TxBlockObj,
   RPCMethod,
+  EventEmitter,
 } from '@zilliqa-js/core';
 import { getAddressFromPublicKey, normaliseAddress } from '@zilliqa-js/crypto';
 import { BN, Long } from '@zilliqa-js/util';
 
-import { TxParams, TxReceipt, TxStatus, TxIncluded } from './types';
+import {
+  TxParams,
+  TxReceipt,
+  TxStatus,
+  TxIncluded,
+  TxEventName,
+  // TxEvents,
+} from './types';
 import { encodeTransactionProto, sleep } from './util';
 
 /**
@@ -59,6 +67,7 @@ export class Transaction implements Signable {
   }
 
   provider: Provider;
+  eventEmitter: EventEmitter<Transaction>;
   id?: string;
   status: TxStatus;
   toDS: boolean;
@@ -144,6 +153,7 @@ export class Transaction implements Signable {
     this.status = status;
     this.toDS = toDS;
     this.blockConfirmation = 0;
+    this.eventEmitter = new EventEmitter();
   }
 
   /**
@@ -206,6 +216,19 @@ export class Transaction implements Signable {
     return this;
   }
 
+  observed(): EventEmitter<Transaction> {
+    try {
+      if (this.eventEmitter.resolve) {
+        this.eventEmitter.resolve(this);
+      }
+    } catch (error) {
+      if (this.eventEmitter.reject) {
+        this.eventEmitter.reject(error);
+      }
+      throw error;
+    }
+    return this.eventEmitter;
+  }
   /**
    * blockConfirm
    *
@@ -234,6 +257,11 @@ export class Transaction implements Signable {
         );
         if (blockLatest.gte(blockNext)) {
           blockChecked = blockLatest;
+          this.emit(TxEventName.Track, {
+            txHash,
+            attempt,
+            currentBlock: blockChecked.toString(),
+          });
           if (await this.trackTx(txHash)) {
             this.blockConfirmation = blockLatest.sub(blockStart).toNumber();
             return this;
@@ -285,6 +313,10 @@ export class Transaction implements Signable {
   ): Promise<Transaction> {
     this.status = TxStatus.Pending;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      this.emit(TxEventName.Track, {
+        txHash,
+        attempt,
+      });
       try {
         if (await this.trackTx(txHash)) {
           return this;
@@ -338,6 +370,7 @@ export class Transaction implements Signable {
     );
 
     if (res.error) {
+      this.emit(TxEventName.Error, res.error);
       return false;
     }
 
@@ -346,6 +379,7 @@ export class Transaction implements Signable {
       ...res.result.receipt,
       cumulative_gas: parseInt(res.result.receipt.cumulative_gas, 10),
     };
+    this.emit(TxEventName.Receipt, this.receipt);
     this.status =
       this.receipt && this.receipt.success
         ? TxStatus.Confirmed
@@ -367,5 +401,8 @@ export class Transaction implements Signable {
     } catch (error) {
       throw error;
     }
+  }
+  private emit(event: TxEventName | string, txEvent: any) {
+    this.eventEmitter.emit(event, { ...txEvent, event });
   }
 }

--- a/packages/zilliqa-js-account/src/types.ts
+++ b/packages/zilliqa-js-account/src/types.ts
@@ -54,3 +54,9 @@ export interface TxParams {
   pubKey?: string;
   signature?: string;
 }
+
+export const enum TxEventName {
+  Error = 'error',
+  Receipt = 'receipt',
+  Track = 'track',
+}

--- a/packages/zilliqa-js-core/src/eventEmitter.ts
+++ b/packages/zilliqa-js-core/src/eventEmitter.ts
@@ -1,0 +1,75 @@
+import mitt from 'mitt';
+
+class EventEmitter<T> {
+  off: (type: string, handler: mitt.Handler) => void;
+  emit: (type: string, event?: any) => void;
+  promise: Promise<T>;
+  resolve?: (value?: T | PromiseLike<T>) => void;
+  reject?: (reason?: any) => void;
+  then?: any;
+  private handlers?: any = {};
+  private emitter: mitt.Emitter;
+  constructor() {
+    this.emitter = new mitt(this.handlers);
+    this.off = this.emitter.off.bind(this);
+    this.emit = this.emitter.emit.bind(this);
+    // tslint:disable-next-line: no-empty
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+    this.then = this.promise.then.bind(this.promise);
+  }
+
+  resetHandlers() {
+    // tslint:disable-next-line: forin
+    for (const i in this.handlers) {
+      delete this.handlers[i];
+    }
+  }
+  on(type: string, handler: mitt.Handler) {
+    this.emitter.on(type, handler);
+    return this;
+  }
+  once(type: string, handler: mitt.Handler) {
+    this.emitter.on(type, (e: any) => {
+      handler(e);
+      this.removeEventListener(type);
+    });
+  }
+
+  addEventListener(type: string, handler: mitt.Handler) {
+    this.emitter.on(type, handler);
+  }
+
+  removeEventListener(type?: string, handler?: mitt.Handler) {
+    if (!type) {
+      this.handlers = {};
+      return;
+    }
+    if (!handler) {
+      delete this.handlers[type];
+    } else {
+      return this.emitter.off(type, handler);
+    }
+  }
+  onError(error: any) {
+    this.emitter.on('error', error);
+    this.removeEventListener('*');
+  }
+  onData(data: any) {
+    this.emitter.on('data', data);
+    this.removeEventListener('*');
+  }
+  listenerCount(listenKey: any) {
+    let count = 0;
+    Object.keys(this.handlers).forEach((val) => {
+      if (listenKey === val) {
+        count += 1;
+      }
+    });
+    return count;
+  }
+}
+
+export { EventEmitter };

--- a/packages/zilliqa-js-core/src/index.ts
+++ b/packages/zilliqa-js-core/src/index.ts
@@ -19,3 +19,4 @@ export * from './net';
 export * from './util';
 export * from './providers/http';
 export * from './constants';
+export * from './eventEmitter';


### PR DESCRIPTION
Made a small eventEmitter, and added to transaction.

## Description
<!-- What is the overall goals of your pull request? -->
To make transaction event observed
<!-- What is the context of your pull request? -->
Transaction Events could not be tracked during confirmation
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Zilliqa-JavaScript-Library/issues/130

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
To create a transaction 
```javascript
const tx= new Transaction(...);

tx.observed().on('track',(trackInfo)=>{
   console.log(trackInfo);
}).on('receipt',(receiptObject)=>{
  console.log(receiptObject);
}).on('error',(error)=>{
  console.log(error)
});

await zilliqa.createTransaction(tx,...);


// output
// {event:'track',....}
// {event:'error',....}
// {event:'receipt',....}

```

<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

