### PR TITLE
fix: contract spec

### DIFF
--- a/packages/zilliqa-js-contract/test/contract.spec.ts
+++ b/packages/zilliqa-js-contract/test/contract.spec.ts
@@ -421,7 +421,7 @@ describe('Contracts', () => {
       .toLowerCase();
     const contractAt = contractFactory.at(b32);
 
-    const sendMock = jest.fn(() => Promise.resolve({ result: 'mock' }));
+    const sendMock = jest.fn().mockResolvedValue({ result: 'mock' });
 
     contractAt.provider.send = sendMock;
     await contractAt.getInit();


### PR DESCRIPTION
## Description
Currently, the Travis CI build is failing since this [build](https://travis-ci.com/Zilliqa/Zilliqa-JavaScript-Library/builds/117238731)

This PR fixes the type error from `contract.spec.ts`.
