### PR TITLE
docs(README.md): update travis badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zilliqa-JavaScript-Library API
-[![Build Status](https://travis-ci.com/Zilliqa/Zilliqa-JavaScript-Library.svg?branch=feature/monorepo)](https://travis-ci.com/Zilliqa/Zilliqa-JavaScript-Library)
+[![Build Status](https://travis-ci.com/Zilliqa/Zilliqa-JavaScript-Library.svg?branch=dev)](https://travis-ci.com/Zilliqa/Zilliqa-JavaScript-Library)
 [![codecov](https://codecov.io/gh/Zilliqa/Zilliqa-JavaScript-Library/branch/feature/monorepo/graph/badge.svg)](https://codecov.io/gh/Zilliqa/Zilliqa)
 [![Gitter chat](http://img.shields.io/badge/chat-on%20gitter-077a8f.svg)](https://gitter.im/Zilliqa/)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)


### PR DESCRIPTION
Currently, the Travis build badge in README.md can be misleading because it shows the status of `branch=feature/monorepo` instead of `branch=dev`

Hence, This PR updates the URL of the build badge.