### PR TITLE
feat(account):add normalizePrivateKey

### DIFF
--- a/packages/zilliqa-js-account/src/account.ts
+++ b/packages/zilliqa-js-account/src/account.ts
@@ -14,6 +14,7 @@
 //   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import * as zcrypto from '@zilliqa-js/crypto';
+import { validation } from '@zilliqa-js/util';
 
 export class Account {
   /**
@@ -43,7 +44,7 @@ export class Account {
   bech32Address: string;
 
   constructor(privateKey: string) {
-    this.privateKey = privateKey;
+    this.privateKey = this.normalizePrivateKey(privateKey);
     this.publicKey = zcrypto.getPubKeyFromPrivateKey(this.privateKey);
     this.address = zcrypto.getAddressFromPublicKey(this.publicKey);
     this.bech32Address = zcrypto.toBech32Address(this.address);
@@ -83,5 +84,16 @@ export class Account {
    */
   signTransaction(bytes: Buffer) {
     return zcrypto.sign(bytes, this.privateKey, this.publicKey);
+  }
+
+  private normalizePrivateKey(privateKey: string) {
+    try {
+      if (!validation.isPrivateKey(privateKey)) {
+        throw new Error('Private key is not correct');
+      }
+      return privateKey.toLowerCase().replace('0x', '');
+    } catch (error) {
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
To normalize private key added to Wallet and Account
<!-- What is the context of your pull request? -->
To ensure the publicKey and address generated are the same
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Zilliqa-JavaScript-Library/issues/157

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->

<!-- How can the reviewers verify the pull request is working as expected -->
```javascript
const key1='aaaaaa...'
const key2=`0x${key1}`

const account1=new Account(key1);
const account2=new Account(key2);

console.log(account1.privateKey===account2.privateKey)
console.log(account1.publicKey===account2.publicKey)
console.log(account1.address===account2.address)

```

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

