### PR TITLE
feat(crypto): add normalizePrivateKey before `secp256k1.keyFromPrivat…

### DIFF
--- a/packages/zilliqa-js-account/src/account.ts
+++ b/packages/zilliqa-js-account/src/account.ts
@@ -14,7 +14,6 @@
 //   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import * as zcrypto from '@zilliqa-js/crypto';
-import { validation } from '@zilliqa-js/util';
 
 export class Account {
   /**
@@ -87,13 +86,6 @@ export class Account {
   }
 
   private normalizePrivateKey(privateKey: string) {
-    try {
-      if (!validation.isPrivateKey(privateKey)) {
-        throw new Error('Private key is not correct');
-      }
-      return privateKey.toLowerCase().replace('0x', '');
-    } catch (error) {
-      throw error;
-    }
+    return zcrypto.normalizePrivateKey(privateKey);
   }
 }


### PR DESCRIPTION
add normalizePrivateKey before `secp256k1.keyFromPrivate` and make a `getAccountFrom0xPrivateKey` to recover those wrongly entered

## Description
<!-- What is the overall goals of your pull request? -->
To normalize privateKey before getting the publicKey and address

<!-- What is the context of your pull request? -->
Previously, we don't have `normalizePrivateKey` before `secp256k1.getFromPrivate`
If developer or user type in a `0x` prefix privateKey, it would calculate publicKey and address, however they are not the correct ones.

eg. Using the example in README.md

```javascript
// Populate the wallet with an account
const privkey = '3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8';

zilliqa.wallet.addByPrivateKey(
  privkey
);
const address = CP.getAddressFromPrivateKey(privkey);

console.log(address)

```
That address is correct because the privateKey is correct.

```bash
0x8254b2C9aCdf181d5d6796d63320fBb20D4Edd12
```

However,

if User input a privateKey with `0x` prefix, the outcome is different

```javascript
// Populate the wallet with an account
const privkey = '0x3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8';

zilliqa.wallet.addByPrivateKey(
  privkey
);
const address = CP.getAddressFromPrivateKey(privkey);

```
That address is different because `secp256k1.fromPrivate` will see the privateKey differnently.

```bash
0x372d8187c13c1A16F17A87B2166B02591B8640b8
```

Now in reality, many wallets and exchanges are using with `0x` prefix, not only the address but also privateKeys. 

When user is using the same privateKey with `0x` prefix like `ethereum` provides. When it is passed to `getAddressFromPrivateKey` or `getPublicKeyFromPrivateKey`, it wont give you the outcome you really want. Especially when you sign a transaction, the `0x` prefixed privateKey won't work, because the `schnorr.trySign` will see it as a `bad private key`.

To solve this problem, we need to normalize privateKey before it is passed to `getAddressFromPrivateKey` and `getPublicKeyFromPrivateKey`.  And make sure that we can get the correct outcome.

**Another problem**

However, if a user had already generated an address or publicKey using `0x`, they might be unable to sign transaction or transfer token.

For example, Alice want to transfer ZIL token to Bob, Bob using a privateKey with `0x` prefix. He use old library to generate an address to receive token. Alice transfer token to the address that Bob has given. Bob can receive token, however when he want to transfer the token to other address, it would not be able to do that. Since the privateKey is `0x`, although he can remove the `0x` by hand, it actually outputs with different publicKey and address.

So Bob may not recover his token forever. because the privateKey is not the correct privateKey to the address he gave to Alice.

But luckily, he always has the 0x `privateKey`, we can use `secp256k1.fromPrivate()` to get the `KeyPair`, and then use the `KeyPair.getPrivate()` to get the correct `privateKey` to the address that given to Alice previously.

I also made a getAccountFrom0xPrivateKey as part of the PR.

```javascript
export const getAccountFrom0xPrivateKey = (privateKeyWith0x: string) => {
  const privateKeyWithout0x = normalizePrivateKey(privateKeyWith0x);
  const keyPair = secp256k1.keyFromPrivate(privateKeyWith0x, 'hex');
  const publicKeyWith0x = keyPair.getPublic(true, 'hex');
  const addressWith0x = getAddressFromPublicKey(publicKeyWith0x);
  const bech32With0x = toBech32Address(addressWith0x);
  const with0x = {
    prv: privateKeyWith0x,
    pub: publicKeyWith0x,
    addr: addressWith0x,
    bech32: bech32With0x,
  };

  const keyPair2 = secp256k1.keyFromPrivate(privateKeyWithout0x, 'hex');
  const publicKeyWithout0x = keyPair2.getPublic(true, 'hex');
  const addressWithout0x = getAddressFromPublicKey(publicKeyWithout0x);
  const bech32Without0x = toBech32Address(addressWithout0x);
  const without0x = {
    prv: privateKeyWithout0x,
    pub: publicKeyWithout0x,
    addr: addressWithout0x,
    bech32: bech32Without0x,
  };

  const privateKeyAfterChange = keyPair.getPrivate('hex');
  const publicKeyAfterChange = keyPair.getPublic(true, 'hex');
  const addressAfterChange = getAddressFromPublicKey(publicKeyAfterChange);
  const bech32AfterChange = toBech32Address(addressAfterChange);

  const changed = {
    prv: privateKeyAfterChange,
    pub: publicKeyAfterChange,
    addr: addressAfterChange,
    bech32: bech32AfterChange,
  };

  return {
    with0x,
    without0x,
    changed,
  };
};

```
When you try the privateKey with `0x`

```javascript

const CP = require('@zilliqa-js/crypto');

const account = CP.getAccountFrom0xPrivateKey(
  '0x3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8',
);

console.log(account);
```
The output is

```bash
{ with0x:
   { prv:
      '0x3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8',
     pub:
      '0249ab77dff3de6f732e99bd43994f1abf44f9bffb4d670e17b878a60364abf66d',
     addr: '0x372d8187c13c1A16F17A87B2166B02591B8640b8',
     bech32: 'zil1xukcrp7p8sdpdut6s7epv6cztydcvs9ct4yl08' },
  without0x:
   { prv:
      '3375f915f3f9ae35e6b301b7670f53ad1a5be15d8221ec7fd5e503f21d3450c8',
     pub:
      '02bd2d38bd776319e685134041615fe3b8e8c674b65353624d2da8e2a6823e1a5b',
     addr: '0x8254b2C9aCdf181d5d6796d63320fBb20D4Edd12',
     bech32: 'zil1sf2t9jdvmuvp6ht8jmtrxg8mkgx5ahgj6h833r' },
  changed:
   { prv:
      '3375f915f3f9ae35e6b301b7670f53b744e4fa2807dceaa1d7520f8b9b8246c0',
     pub:
      '0249ab77dff3de6f732e99bd43994f1abf44f9bffb4d670e17b878a60364abf66d',
     addr: '0x372d8187c13c1A16F17A87B2166B02591B8640b8',
     bech32: 'zil1xukcrp7p8sdpdut6s7epv6cztydcvs9ct4yl08' } }

```
You can see the `changed.prv` is different from `with0x.prv`, but the address(checksum and bech32) and pub are the same.

Bob can recover with the new `changed.prv` to recover his fund.


<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Zilliqa-JavaScript-Library/issues/157


## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Please add unit test cases to the crypto packages
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

