### PR TITLE
feat(blockchain): create transaction without confirm

### DIFF
--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -13,24 +13,24 @@
 //   You should have received a copy of the GNU General Public License
 //   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Transaction, Wallet, util } from '@zilliqa-js/account';
+import { Transaction, util, Wallet } from '@zilliqa-js/account';
 import { fromBech32Address } from '@zilliqa-js/crypto';
 import { validation } from '@zilliqa-js/util';
 import { ContractObj, Value } from '@zilliqa-js/contract';
 import {
-  GET_TX_ATTEMPTS,
-  sign,
-  Provider,
-  ZilliqaModule,
-  RPCResponse,
-  RPCMethod,
   BlockchainInfo,
-  DsBlockObj,
   BlockList,
+  DsBlockObj,
+  GET_TX_ATTEMPTS,
+  Provider,
+  RPCMethod,
+  RPCResponse,
+  ShardingStructure,
+  sign,
+  TransactionObj,
   TxBlockObj,
   TxList,
-  TransactionObj,
-  ShardingStructure,
+  ZilliqaModule,
 } from '@zilliqa-js/core';
 
 import { Omit } from 'utility-types';
@@ -286,6 +286,23 @@ export class Blockchain implements ZilliqaModule {
         return tx.blockConfirm(response.result.TranID, maxAttempts, interval);
       }
       return tx.confirm(response.result.TranID, maxAttempts, interval);
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  @sign
+  async createTransactionWithoutConfirm(tx: Transaction): Promise<Transaction> {
+    try {
+      const response = await this.provider.send(RPCMethod.CreateTransaction, {
+        ...tx.txParams,
+        priority: tx.toDS,
+      });
+      if (response.error) {
+        throw response.error;
+      }
+      tx.id = response.result.TranID;
+      return tx;
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## Description
Create a function to let users send transaction without waiting for the confirm.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

