### PR TITLE
feat(core): add penging transaction support

### DIFF
--- a/examples/helloWord.js
+++ b/examples/helloWord.js
@@ -43,7 +43,7 @@ async function testBlockchain() {
 
     // Send a transaction to the network
     console.log('Sending a payment transaction to the network...');
-    const tx = await zilliqa.blockchain.createTransaction(
+    const tx = await zilliqa.blockchain.createTransactionWithoutConfirm(
       // Notice here we have a default function parameter named toDs which means the priority of the transaction.
       // If the value of toDs is false, then the transaction will be sent to a normal shard, otherwise, the transaction.
       // will be sent to ds shard. More info on design of sharding for smart contract can be found in.
@@ -61,8 +61,24 @@ async function testBlockchain() {
       ),
     );
 
+    // check the pending status
+    const pendingStatus = await zilliqa.blockchain.getPendingTxn(tx.id);
+    console.log(`Pending status is: `);
+    console.log(pendingStatus.result);
+
+    // process confirm
+    console.log(`The transaction id is:`, tx.id);
+    const confirmedTxn = await tx.confirm(tx.id);
+
     console.log(`The transaction status is:`);
-    console.log(tx.receipt);
+    console.log(confirmedTxn.receipt);
+
+    // check the pending status after confirming
+    const pendingStatusAfterConfirming = await zilliqa.blockchain.getPendingTxn(
+      tx.id,
+    );
+    console.log(`Pending status is: `);
+    console.log(pendingStatusAfterConfirming.result);
 
     // Deploy a contract
     console.log(`Deploying a new contract....`);

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -22,6 +22,7 @@ import {
   BlockList,
   DsBlockObj,
   GET_TX_ATTEMPTS,
+  PendingTxnResult,
   Provider,
   RPCMethod,
   RPCResponse,
@@ -399,6 +400,18 @@ export class Blockchain implements ZilliqaModule {
    */
   getMinimumGasPrice() {
     return this.provider.send<string, string>(RPCMethod.GetMinimumGasPrice);
+  }
+
+  /**
+   * getPendingTxn
+   * See the pending status of transaction
+   * @param tx
+   */
+  getPendingTxn(tx: string): Promise<RPCResponse<PendingTxnResult, string>> {
+    return this.provider.send(
+      RPCMethod.GetPendingTxn,
+      tx.replace('0x', '').toLowerCase(),
+    );
   }
 
   /**

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -405,12 +405,12 @@ export class Blockchain implements ZilliqaModule {
   /**
    * getPendingTxn
    * See the pending status of transaction
-   * @param tx
+   * @param txId
    */
-  getPendingTxn(tx: string): Promise<RPCResponse<PendingTxnResult, string>> {
+  getPendingTxn(txId: string): Promise<RPCResponse<PendingTxnResult, string>> {
     return this.provider.send(
       RPCMethod.GetPendingTxn,
-      tx.replace('0x', '').toLowerCase(),
+      txId.replace('0x', '').toLowerCase(),
     );
   }
 

--- a/packages/zilliqa-js-core/src/net.ts
+++ b/packages/zilliqa-js-core/src/net.ts
@@ -52,6 +52,7 @@ export const enum RPCMethod {
   GetNumTxnsTxEpoch = 'GetNumTxnsTxEpoch',
   GetNumTxnsDSEpoch = 'GetNumTxnsDSEpoch',
   GetMinimumGasPrice = 'GetMinimumGasPrice',
+  GetPendingTxn = 'GetPendingTxn',
 
   // Contract-related methods
   GetSmartContracts = 'GetSmartContracts',

--- a/packages/zilliqa-js-core/src/types.ts
+++ b/packages/zilliqa-js-core/src/types.ts
@@ -28,7 +28,9 @@ export interface Provider {
     method: string,
     ...params: any[]
   ): Promise<RPCResponse<R, E>>;
+
   subscribe?(event: string, subscriber: Subscriber): symbol;
+
   unsubscribe?(token: symbol): void;
 }
 
@@ -194,4 +196,10 @@ export interface EventParam {
   vname: string;
   type: string;
   value: string;
+}
+
+export interface PendingTxnResult {
+  code: number;
+  confirmed: boolean;
+  info: string;
 }


### PR DESCRIPTION
## Description
Add support for checking transaction's pending status:

```
const response  = await zilliqa.blockchain.getPendingTxn('0x2cf109b25f2132c08a4248e2be8add6b95b92aef5b2c77e737faefbc9353ee7c');
console.log(response.result);
```

The result could be:

```
{ code: 0,
  confirmed: true,
  info: 'Txn already processed and confirmed' }
```
or something else similar
 
```
{ code: 1,
  confirmed: false,
  info: 'Nonce too high' }
```
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

