### PR TITLE
fix: remote paramter testnet while doing bech32 conversion

### DIFF
--- a/packages/zilliqa-js-crypto/src/bech32.ts
+++ b/packages/zilliqa-js-crypto/src/bech32.ts
@@ -138,7 +138,6 @@ export const decode = (bechString: string) => {
 
 // HRP is the human-readable part of zilliqa bech32 addresses
 export const HRP = 'zil';
-export const tHRP = 'tzil';
 
 /**
  * convertBits
@@ -202,10 +201,7 @@ export const convertBits = (
  * @param {string} 20 byte canonical address
  * @returns {string} 38 char bech32 encoded zilliqa address
  */
-export const toBech32Address = (
-  address: string,
-  testnet: boolean = false,
-): string => {
+export const toBech32Address = (address: string): string => {
   if (!validation.isAddress(address)) {
     throw new Error('Invalid address format.');
   }
@@ -220,7 +216,7 @@ export const toBech32Address = (
     throw new Error('Could not convert byte Buffer to 5-bit Buffer');
   }
 
-  return encode(testnet ? tHRP : HRP, addrBz);
+  return encode(HRP, addrBz);
 };
 
 /**
@@ -229,10 +225,7 @@ export const toBech32Address = (
  * @param {string} address - a valid Zilliqa bech32 address
  * @returns {string} a canonical 20-byte Ethereum-style address
  */
-export const fromBech32Address = (
-  address: string,
-  testnet: boolean = false,
-): string => {
+export const fromBech32Address = (address: string): string => {
   const res = decode(address);
 
   if (res === null) {
@@ -241,7 +234,7 @@ export const fromBech32Address = (
 
   const { hrp, data } = res;
 
-  const shouldBe = testnet ? tHRP : HRP;
+  const shouldBe = HRP;
   if (hrp !== shouldBe) {
     throw new Error(`Expected hrp to be ${shouldBe} but got ${hrp}`);
   }

--- a/packages/zilliqa-js-util/src/validation.ts
+++ b/packages/zilliqa-js-util/src/validation.ts
@@ -20,10 +20,8 @@ export const isAddress = (address: string) => {
   return isByteString(address, 40);
 };
 
-export const isBech32 = (raw: string, testnet: boolean = false) => {
-  return testnet
-    ? !!raw.match(/^tzil1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}/)
-    : !!raw.match(/^zil1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}/);
+export const isBech32 = (raw: string) => {
+  return !!raw.match(/^zil1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}/);
 };
 
 export const isBase58 = (raw: string) => {


### PR DESCRIPTION
## Description
Since we have network id, actually we don't need parameter `testnet` to distinguish different networks while doing bech32 conversion. In other works, `testnet` and `mainnet` can share only one standard on address format.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

