### PR TITLE
chore(readme): change time from 100 to 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ async function testBlockchain() {
         gasLimit: Long.fromNumber(8000),
       },
       33,
-      100,
+      1000,
       false,
     );
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The default time interval is set to `1000` in the SDK. However, in the readme example, it was set to `100`, which will be too short and will hit the time limit before the transaction gets confirm in the block. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

