### PR TITLE
fix(account): fix sign error with nonce being passed explicitly

### DIFF
--- a/packages/zilliqa-js-account/src/wallet.ts
+++ b/packages/zilliqa-js-account/src/wallet.ts
@@ -258,7 +258,14 @@ export class Wallet extends Signer {
         });
       }
 
-      return tx.map((txObj) => {
+      const withPublicKey = tx.map((txObj) => {
+        return {
+          ...txObj,
+          pubKey: signer.publicKey,
+        };
+      });
+
+      return withPublicKey.map((txObj) => {
         return {
           ...txObj,
           signature: signer.signTransaction(tx.bytes),


### PR DESCRIPTION
## Description
The overall goals of this pull request is to fix sign procedure once user pass `nonce` explicitly. Currently situation is, if user pass `nonce` while constructing transaction object, the field `pubKey` will be missed.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

