### PR TITLE
feat(contract): support calling contract without confirming

### DIFF
--- a/packages/zilliqa-js-contract/src/contract.ts
+++ b/packages/zilliqa-js-contract/src/contract.ts
@@ -250,6 +250,44 @@ export class Contract {
     }
   }
 
+  async callWithoutConfirm(
+    transition: string,
+    args: Value[],
+    params: CallParams,
+    toDs: boolean = false,
+  ): Promise<Transaction> {
+    const data = {
+      _tag: transition,
+      params: args,
+    };
+
+    if (this.error) {
+      return Promise.reject(this.error);
+    }
+
+    if (!this.address) {
+      return Promise.reject('Contract has not been deployed!');
+    }
+
+    const tx = new Transaction(
+      {
+        ...params,
+        toAddr: this.address,
+        data: JSON.stringify(data),
+      },
+      this.provider,
+      TxStatus.Initialised,
+      toDs,
+    );
+
+    try {
+      await this.prepare(tx);
+      return tx;
+    } catch (err) {
+      throw err;
+    }
+  }
+
   /**
    * call
    *


### PR DESCRIPTION
## Description
To separate confirming procedure from contract calling. Similar to `deployWithoutConfirm` or `createTransactionWithoutConfirm`, in other words, people can get transaction id immediately then process waiting for confirmation later. Also add unit test and example script.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

