### PR TITLE
Provide addByMnemonicLedger() for derivation path used in Ledger

### DIFF
--- a/packages/zilliqa-js-account/src/wallet.ts
+++ b/packages/zilliqa-js-account/src/wallet.ts
@@ -133,6 +133,28 @@ export class Wallet extends Signer {
   }
 
   /**
+   * addByMnemonicLedger
+   *
+   * Adds an `Account` by use of a mnemonic as specified in BIP-32 and BIP-39
+   * The key derivation path used in Ledger is different from that of
+   * addByMnemonic.
+   *
+   * @param {string} phrase - 12-word mnemonic phrase
+   * @param {number} index=0 - the number of the child key to add
+   * @returns {string} - the corresponding address
+   */
+  addByMnemonicLedger(phrase: string, index: number = 0): string {
+    if (!this.isValidMnemonic(phrase)) {
+      throw new Error(`Invalid mnemonic phrase: ${phrase}`);
+    }
+    const seed = bip39.mnemonicToSeed(phrase);
+    const hdKey = hdkey.fromMasterSeed(seed);
+    const childKey = hdKey.derive(`m/44'/313'/${index}'/0'/0'`);
+    const privateKey = childKey.privateKey.toString('hex');
+    return this.addByPrivateKey(privateKey);
+  }
+
+  /**
    * export
    *
    * Exports the specified account as a keystore file.


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
Provide a wallet method to add account based on a mnemonic phrase, but compatible with Ledger.
<!-- What is the context of your pull request? -->
The key derivation  used in the Ledger app is different from the one used by other wallets. To enable recovery of Ledger wallets based on their mnemonic phrase in non Ledger wallets, this method is now provided.
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

