### PR TITLE
fix/remove-const-enum

### DIFF
--- a/packages/zilliqa-js-account/src/types.ts
+++ b/packages/zilliqa-js-account/src/types.ts
@@ -16,7 +16,7 @@
 import { BN, Long } from '@zilliqa-js/util';
 import { TransactionReceiptObj } from '@zilliqa-js/core';
 
-export const enum TxStatus {
+export enum TxStatus {
   Initialised,
   Pending,
   Confirmed,
@@ -55,7 +55,7 @@ export interface TxParams {
   signature?: string;
 }
 
-export const enum TxEventName {
+export enum TxEventName {
   Error = 'error',
   Receipt = 'receipt',
   Track = 'track',

--- a/packages/zilliqa-js-contract/src/types.ts
+++ b/packages/zilliqa-js-contract/src/types.ts
@@ -16,7 +16,7 @@
 import { Omit } from 'utility-types';
 import { TxParams } from '@zilliqa-js/account';
 
-export const enum ContractStatus {
+export enum ContractStatus {
   Deployed,
   Rejected,
   Initialised,

--- a/packages/zilliqa-js-core/src/errors.ts
+++ b/packages/zilliqa-js-core/src/errors.ts
@@ -13,7 +13,7 @@
 //   You should have received a copy of the GNU General Public License
 //   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-export const enum Errors {
+export enum Errors {
   // Unknown Error
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
 

--- a/packages/zilliqa-js-core/src/net.ts
+++ b/packages/zilliqa-js-core/src/net.ts
@@ -20,7 +20,7 @@ import { WithRequest } from './util';
 /**
  * blockchain-side.
  */
-export const enum RPCMethod {
+export enum RPCMethod {
   // Network-related methods
   GetNetworkId = 'GetNetworkId',
 
@@ -70,7 +70,7 @@ export const enum RPCMethod {
   GetBalance = 'GetBalance',
 }
 
-export const enum RPCErrorCode {
+export enum RPCErrorCode {
   // Standard JSON-RPC 2.0 errors
   // RPC_INVALID_REQUEST is internally mapped to HTTP_BAD_REQUEST (400).
   // It should not be used for application-layer errors.

--- a/packages/zilliqa-js-subscriptions/src/types.ts
+++ b/packages/zilliqa-js-subscriptions/src/types.ts
@@ -15,7 +15,7 @@
 
 import { IClientConfig } from 'websocket';
 
-export const enum SocketConnect {
+export enum SocketConnect {
   READY = 'ready',
   CONNECT = 'connect',
   ERROR = 'error',
@@ -23,7 +23,7 @@ export const enum SocketConnect {
   RECONNECT = 'reconnect',
 }
 
-export const enum SocketState {
+export enum SocketState {
   SOCKET_CONNECT = 'socket_connect',
   SOCKET_MESSAGE = 'socket_message',
   SOCKET_READY = 'socket_ready',
@@ -32,7 +32,7 @@ export const enum SocketState {
 }
 
 // message type pushed by server side
-export const enum MessageType {
+export enum MessageType {
   NEW_BLOCK = 'NewBlock',
   EVENT_LOG = 'EventLog',
   NOTIFICATION = 'Notification',
@@ -40,14 +40,14 @@ export const enum MessageType {
 }
 
 // message type that we can query with to server
-export const enum QueryParam {
+export enum QueryParam {
   NEW_BLOCK = 'NewBlock',
   EVENT_LOG = 'EventLog',
   UNSUBSCRIBE = 'Unsubscribe',
 }
 
 // indicate that whether we subscribe successfully
-export const enum StatusType {
+export enum StatusType {
   SUBSCRIBE_NEW_BLOCK = 'SubscribeNewBlock',
   SUBSCRIBE_EVENT_LOG = 'SubscribeEventLog',
 }

--- a/packages/zilliqa-js-util/src/unit.ts
+++ b/packages/zilliqa-js-util/src/unit.ts
@@ -18,7 +18,7 @@
  */
 import BN from 'bn.js';
 
-export const enum Units {
+export enum Units {
   Zil = 'zil',
   Li = 'li',
   Qa = 'qa',


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Remove the `const` keyword as it cause access errors for TypeScript compilers which are configured to enable `isolatedModules: true` in their `tsconfig.json`, e.g. the `dev-explorer` project. 

See https://ncjamieson.com/dont-export-const-enums/ for explanation on `export const enum` vs `export enum` compilation. Also see https://stackoverflow.com/questions/28818849/how-do-the-different-enum-variants-work-in-typescript for different enum variants. 

This pr does not affect current implementation; enumerations still can be accessed via `Var.Enum`

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
- bootstrap and run unit tests

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

