### PR TITLE
feat/pendingtxn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 includes
 tsconfig.tsbuildinfo
 .env
+.idea/
 coverage
 devTestOnly/
 @zilliqa-js*

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -531,8 +531,8 @@ export class Blockchain implements ZilliqaModule {
         return Promise.reject(response.error);
       }
 
-      if (response.result.length > 0) {
-        response.result.forEach((tnx: TransactionStatus) => {
+      if (response.result.Txns.length) {
+        response.result.Txns.forEach((tnx: TransactionStatus) => {
           tnx.info = this.pendingErrorMap[tnx.code];
         });
       }

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -532,8 +532,8 @@ export class Blockchain implements ZilliqaModule {
       }
 
       if (response.result.Txns.length) {
-        response.result.Txns.forEach((tnx: TransactionStatus) => {
-          tnx.info = this.pendingErrorMap[tnx.code];
+        response.result.Txns.forEach((txn: TransactionStatus) => {
+          txn.info = this.pendingErrorMap[txn.code];
         });
       }
 

--- a/packages/zilliqa-js-blockchain/test/chain.spec.ts
+++ b/packages/zilliqa-js-blockchain/test/chain.spec.ts
@@ -292,7 +292,7 @@ describe('Module: Blockchain', () => {
         result: {
           Txns: [
             {
-              Status: 1,
+              code: 1,
               TxnHash:
                 'ec5ef8110a285563d0104269081aa77820058067091a9b3f3ae70f38b94abda3',
             },
@@ -303,13 +303,14 @@ describe('Module: Blockchain', () => {
 
     fetch.mockResponses(...responses);
     const result = await blockchain.getPendingTxns();
-    expect(result.result).toBeDefined();
+    expect(result.Txns).toBeDefined();
     // @ts-ignore
-    expect(result.result.Txns).toEqual([
+    expect(result.Txns).toEqual([
       {
-        Status: 1,
+        code: 1,
         TxnHash:
           'ec5ef8110a285563d0104269081aa77820058067091a9b3f3ae70f38b94abda3',
+        info: 'Pending - nonce too high',
       },
     ]);
   });

--- a/packages/zilliqa-js-core/src/types.ts
+++ b/packages/zilliqa-js-core/src/types.ts
@@ -115,7 +115,7 @@ export interface BlockList {
   maxPages: number;
 }
 
-const enum TxBlockType {
+enum TxBlockType {
   MICRO,
   FINAL,
 }
@@ -209,6 +209,7 @@ export interface EventLogEntry {
 }
 
 export interface TransitionEntry {
+  accepted: boolean;
   addr: string;
   depth: number;
   msg: TransitionMsg;

--- a/packages/zilliqa-js-core/src/types.ts
+++ b/packages/zilliqa-js-core/src/types.ts
@@ -232,8 +232,9 @@ export interface PendingTxns {
 }
 
 export interface TransactionStatus {
-  Status: number;
+  code: number;
   TxnHash: string;
+  info: string;
 }
 
 export interface PendingTxnResult {

--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -285,7 +285,12 @@ export const decodeBase58 = (raw: string): string => {
   }
 
   let res = leader + n.toString('hex');
-  if (res.length % 2 !== 0) {
+
+  // handle corner case node12
+  if (res.length % 2 !== 0 && res.length > 40) {
+    res = res.substring(1);
+  }
+  if (res.length % 2 !== 0 && res.length < 40) {
     res = '0' + res;
   }
 

--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -218,6 +218,7 @@ export const normaliseAddress = (address: string): string => {
 /**
  * encodeBase58
  *
+ * @deprecated since version 1.0.0
  * @param {string} hex - base 16 encoded string
  * @returns {string} - big endian base 58 encoded string
  */
@@ -253,6 +254,7 @@ export const encodeBase58 = (hex: string): string => {
 /**
  * decodeBase58
  *
+ * @deprecated since version 1.0.0
  * @param {string} raw - base 58 string
  * @returns {string} - big endian base 16 string
  */

--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -285,12 +285,7 @@ export const decodeBase58 = (raw: string): string => {
   }
 
   let res = leader + n.toString('hex');
-
-  // handle corner case node12
-  if (res.length % 2 !== 0 && res.length > 40) {
-    res = res.substring(1);
-  }
-  if (res.length % 2 !== 0 && res.length < 40) {
+  if (res.length % 2 !== 0) {
     res = '0' + res;
   }
 

--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -216,7 +216,7 @@ export const normaliseAddress = (address: string): string => {
 };
 
 /**
- * encodeBase58
+ * encodeBase58 -the function currently not in use, so we will deprecate it
  *
  * @deprecated since version 1.0.0
  * @param {string} hex - base 16 encoded string
@@ -252,7 +252,7 @@ export const encodeBase58 = (hex: string): string => {
 };
 
 /**
- * decodeBase58
+ * decodeBase58 - the function currently not in use, so we will deprecate it
  *
  * @deprecated since version 1.0.0
  * @param {string} raw - base 58 string

--- a/packages/zilliqa-js-crypto/test/util.spec.ts
+++ b/packages/zilliqa-js-crypto/test/util.spec.ts
@@ -16,7 +16,6 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { decodeBase58, encodeBase58, normalizePrivateKey } from '../src/util';
-import { randomBytes } from '../src/random';
 import testCases from './b58.fixtures.json';
 
 describe('crypto utils', () => {
@@ -35,7 +34,7 @@ describe('crypto utils', () => {
   });
 
   it('should encode and decode to the same strings', () => {
-    const b16 = randomBytes(20);
+    const b16 = 'fa629547ab288cdd7f726fc0610abe944c982a1d';
     const b58 = encodeBase58(b16);
     expect(decodeBase58(b58)).toEqual(b16);
   });


### PR DESCRIPTION
## Description
1. The main purpose of this PR is to refactor `GetPendingTxns` and `GetPendingTxn` based on the modification of node side. Besides, sdk also automatically map `code` to more readable and concrete string message. More detail one can refer to [this document for pending transaction](https://github.com/Zilliqa/dev-docs/blob/update_pend_txns/core/pending-txn.md).

2. Fix two other interfaces.

3. Deprecate two base58 functions.

## Review Suggestion
1. Try to create some pending transactions, e.g send a transaction with a higher nonce.
2. Run script like follows:

```typescript
const { Zilliqa } = require('@zilliqa-js/zilliqa');

const zilliqa = new Zilliqa('https://api-dev.zilliqa.com/');

async function test() {
  try {
    const pending = await zilliqa.blockchain.getPendingTxn('d6b8b4c723c2c6468482368e9b0f0b2bd91d9766189111819346f0cdadb09807');
    console.log(pending);
  } catch (e) {
    console.log(e);
  }
}
```

3. Run script like follows:

```typescript
const { Zilliqa } = require('@zilliqa-js/zilliqa');

const zilliqa = new Zilliqa('https://api-dev.zilliqa.com/');

async function test() {
  try {
    const pending = await zilliqa.blockchain.getPendingTxns();
    console.log(pending);
  } catch (e) {
    console.log(e);
  }
}
test();
```


## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

