### PR TITLE
change node-sodium to sodium-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ want to use it for.
 | [`@zilliqa-js/util`](./packages/zilliqa-js-util)       | Miscellaneous functions that take care of serialisation/deserialisation and validation.                                                                                   | none                                                                                    |
 | [`@zilliqa-js/viewblock`](https://github.com/Ashlar/zilliqa-js-viewblock)       | Library interfacing with ViewBlock's APIs                                                                                   | `@zilliqa-js/crypto`                                                                                    |
 
+
+## Pre-Requisite (Windows Users)
+
+`zilliqa-js` uses [`scrypt`](https://www.npmjs.com/package/scrypt) library which depends on `node-gyp` in order to compile the binaries from source on Windows. 
+`node-gyp` on Windows requires users to install additional Visual Studio Build tools.
+
+To install the required Visual Studio Build tools:
+
+```shell
+npm install --global --production windows-build-tools # from an elevated PowerShell or CMD.exe as Administrator
+
+npm config set msvs_version 2015 # 2015 is more compatible; though 2017 may work too
+```
+
+Refer to https://github.com/nodejs/node-gyp#installation for more information about `node-gyp` installation on Windows.
+
+
 ## Installation
 
 It is recommended that developers install the JavaScript client by making use

--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -37,7 +37,7 @@
     "pbkdf2": "^3.0.16",
     "randombytes": "^2.0.6",
     "scryptsy": "^2.1.0",
-    "sodium": "^3.0.2",
+    "sodium-native": "^3.2.0",
     "uuid": "^3.3.2"
   }
 }

--- a/packages/zilliqa-js-crypto/src/random.ts
+++ b/packages/zilliqa-js-crypto/src/random.ts
@@ -35,7 +35,8 @@ export const randomBytes = (bytes: number) => {
     randBz = window.crypto.getRandomValues(new Uint8Array(bytes));
   } else if (typeof require !== 'undefined') {
     const b = Buffer.allocUnsafe(bytes);
-    require('sodium').api.randombytes_buf(b, bytes);
+    const sodium = require('sodium-native');
+    sodium.randombytes_buf(b);
     randBz = new Uint8Array(
       b.buffer,
       b.byteOffset,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,7 +5832,7 @@ inherits@2.0.3:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7817,11 +7817,6 @@ nice-try@^1.0.4:
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-addon-api@*:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.1.tgz#990544a2607ec3f538443df4858f8c40089b7783"
-  integrity sha512-YUpjl57P55u2yUaKX5Bgy4t5s6SCNYMg+62XNg+k41aYbBL1NgWrZfcgljR5MxDxHDjzl0qHDNtH6SkW4DXNCA==
-
 node-fetch-npm@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
@@ -7840,6 +7835,11 @@ node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp@^5.0.2:
   version "5.0.5"
@@ -9856,12 +9856,13 @@ socks@~2.3.2:
     ip "^1.1.5"
     smart-buffer "4.0.2"
 
-sodium@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/sodium/-/sodium-3.0.2.tgz#4dbd7eb4a21c92ca7e7f684756cd733fee78112e"
-  integrity sha512-IsTwTJeoNBU97km3XkrbCGC/n/9aUQejgD3QPr2YY2gtbSPru3TI6nhCqgoez9Mv88frF9oVZS/jrXFbd6WXyA==
+sodium-native@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz#68a9469b96edadffef320cbce51294ad5f72a37f"
+  integrity sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==
   dependencies:
-    node-addon-api "*"
+    ini "^1.3.5"
+    node-gyp-build "^4.2.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This pr replaces the [`node-sodium`](https://github.com/paixaop/node-sodium) package  with [`sodium-native`](https://github.com/sodium-friends/sodium-native). The current `node-sodium` package compiles and builds from source during package install. 

This poses an issue on Windows based machines as it requires the users to install Visual Studio Build tools (about 3~5GB) for `node-gyp` library to build the `sodium` package. This further creates inconvenience to users who attempts to incorporate ZilliqaJS into a Docker image.

This pr uses `sodium-native`, a wrapper around [`libsodium`](https://github.com/jedisct1/libsodium) which is `sodium`  compiled to WebAssembly and pure JavaScript and is recommended from https://doc.libsodium.org/bindings_for_other_languages. 

## Review Suggestion
How to use `zilliqaJS-crypto randomBytes` (with sodium-native utilization):
```
const { randomBytes } = require('@zilliqa-js/crypto');

function test() {
    const addr = randomBytes(20);
    console.log("addr: %o", addr);
}

test()
```

How to use `sodium-native`:
```
const sodium = require('sodium-native')

function test() {
    const b = Buffer.allocUnsafe(64);
    const sodium = require('sodium-native');
    sodium.randombytes_buf(b);
    var hexStr = b.toString('hex');
    console.log(hexStr);
}

test()
```

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### References
sodium-native source: https://github.com/sodium-friends/sodium-native
sodium-native docs: https://sodium-friends.github.io/docs/docs/getstarted
libsodium source: https://github.com/jedisct1/libsodium

