### PR TITLE
fix/undepreciate-base58

### DIFF
--- a/packages/zilliqa-js-crypto/src/util.ts
+++ b/packages/zilliqa-js-crypto/src/util.ts
@@ -216,9 +216,9 @@ export const normaliseAddress = (address: string): string => {
 };
 
 /**
- * encodeBase58 -the function currently not in use, so we will deprecate it
+ * encodeBase58 - may be required for DID public key
+ * undeprecating this function after version 2.0.0
  *
- * @deprecated since version 1.0.0
  * @param {string} hex - base 16 encoded string
  * @returns {string} - big endian base 58 encoded string
  */
@@ -252,9 +252,9 @@ export const encodeBase58 = (hex: string): string => {
 };
 
 /**
- * decodeBase58 - the function currently not in use, so we will deprecate it
+ * decodeBase58 - may be required for DID public key
+ * undeprecating this function after version 2.0.0
  *
- * @deprecated since version 1.0.0
  * @param {string} raw - base 58 string
  * @returns {string} - big endian base 16 string
  */


### PR DESCRIPTION
This is a PR for Issue https://github.com/Zilliqa/Zilliqa-JavaScript-Library/issues/259.

This pr removes the `@deprecated` tags from base58 utility functions.
