### PR TITLE
feat/offline-signing

### DIFF
--- a/examples/node/callContract.js
+++ b/examples/node/callContract.js
@@ -53,7 +53,7 @@ async function testBlockchain() {
     console.log(`Your account balance is:`);
     console.log(balance.result);
     console.log(`Current Minimum Gas Price: ${minGasPrice.result}`);
-    const myGasPrice = units.toQa('1000', units.Units.Li); // Gas Price that will be used by all transactions
+    const myGasPrice = units.toQa('2000', units.Units.Li); // Gas Price that will be used by all transactions
     console.log(`My Gas Price ${myGasPrice.toString()}`);
     const isGasSufficient = myGasPrice.gte(new BN(minGasPrice.result)); // Checks if your gas price is less than the minimum gas price
     console.log(`Is the gas price sufficient? ${isGasSufficient}`);

--- a/examples/node/deployContract.js
+++ b/examples/node/deployContract.js
@@ -53,7 +53,7 @@ async function testBlockchain() {
     console.log(`Your account balance is:`);
     console.log(balance.result);
     console.log(`Current Minimum Gas Price: ${minGasPrice.result}`);
-    const myGasPrice = units.toQa('1000', units.Units.Li); // Gas Price that will be used by all transactions
+    const myGasPrice = units.toQa('2000', units.Units.Li); // Gas Price that will be used by all transactions
     console.log(`My Gas Price ${myGasPrice.toString()}`);
     const isGasSufficient = myGasPrice.gte(new BN(minGasPrice.result)); // Checks if your gas price is less than the minimum gas price
     console.log(`Is the gas price sufficient? ${isGasSufficient}`);

--- a/examples/node/helloWord.js
+++ b/examples/node/helloWord.js
@@ -53,7 +53,7 @@ async function testBlockchain() {
     console.log(`Your account balance is:`);
     console.log(balance.result);
     console.log(`Current Minimum Gas Price: ${minGasPrice.result}`);
-    const myGasPrice = units.toQa('1000', units.Units.Li); // Gas Price that will be used by all transactions
+    const myGasPrice = units.toQa('2000', units.Units.Li); // Gas Price that will be used by all transactions
     console.log(`My Gas Price ${myGasPrice.toString()}`);
     const isGasSufficient = myGasPrice.gte(new BN(minGasPrice.result)); // Checks if your gas price is less than the minimum gas price
     console.log(`Is the gas price sufficient? ${isGasSufficient}`);

--- a/examples/node/walletSign.js
+++ b/examples/node/walletSign.js
@@ -65,6 +65,7 @@ async function offlineSign() {
     const balance = await zilliqa.blockchain.getBalance(address);
     console.log('current nonce is: %o', balance.result.nonce);
 
+    // nonce must be EXPLICITLY DEFINED when flag is 'false'
     const tx = zilliqa.transactions.new(
       {
         version: VERSION,

--- a/examples/node/walletSign.js
+++ b/examples/node/walletSign.js
@@ -1,0 +1,89 @@
+const { BN, Long, bytes, units } = require('@zilliqa-js/util');
+const { Zilliqa } = require('@zilliqa-js/zilliqa');
+const { getAddressFromPrivateKey } = require('@zilliqa-js/crypto');
+
+const zilliqa = new Zilliqa('https://dev-api.zilliqa.com');
+const chainId = 333; // chainId of the developer testnet
+const msgVersion = 1; // current msgVersion
+const VERSION = bytes.pack(chainId, msgVersion);
+const myGasPrice = units.toQa('2000', units.Units.Li);
+
+// Populate the wallet with an account
+const privateKey =
+  '3375F915F3F9AE35E6B301B7670F53AD1A5BE15D8221EC7FD5E503F21D3450C8';
+
+zilliqa.wallet.addByPrivateKey(privateKey);
+
+/**
+ *
+ * wallet.sign(tx)
+ *
+ * example of "online" signing, nonce is NOT REQUIRED in the Transaction obj
+ * nonce is automatically computed inteernally with GetBalance
+ *
+ */
+async function onlineSign() {
+  try {
+    console.log('Online signing with balance check...\n');
+
+    const address = getAddressFromPrivateKey(privateKey);
+    const balance = await zilliqa.blockchain.getBalance(address);
+    console.log('current nonce is: %o', balance.result.nonce);
+
+    const tx = zilliqa.transactions.new(
+      {
+        version: VERSION,
+        toAddr: '0xA54E49719267E8312510D7b78598ceF16ff127CE',
+        amount: new BN(units.toQa('1', units.Units.Zil)),
+        gasPrice: myGasPrice,
+        gasLimit: Long.fromNumber(1),
+      },
+      false,
+    );
+    const result = await zilliqa.wallet.sign(tx);
+    console.log('txn nonce: %o', result.nonce);
+    console.log('txn signature: %o', result.signature);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+/**
+ *
+ * wallet.sign(tx, false)
+ * explicit 'false' flag implies skipping balance check
+ *
+ * example of "offline" signing, nonce is REQUIRED in the Transaction obj
+ * nonce MUST BE SUPPLIED
+ *
+ */
+async function offlineSign() {
+  try {
+    console.log('Offline signing with balance check...\n');
+
+    const address = getAddressFromPrivateKey(privateKey);
+    const balance = await zilliqa.blockchain.getBalance(address);
+    console.log('current nonce is: %o', balance.result.nonce);
+
+    const tx = zilliqa.transactions.new(
+      {
+        version: VERSION,
+        nonce: 9999,
+        toAddr: '0xA54E49719267E8312510D7b78598ceF16ff127CE',
+        amount: new BN(units.toQa('1', units.Units.Zil)),
+        gasPrice: myGasPrice,
+        gasLimit: Long.fromNumber(1),
+      },
+      false,
+    );
+    const result = await zilliqa.wallet.sign(tx, false);
+    console.log('txn nonce: %o', result.nonce);
+    console.log('txn signature: %o', result.signature);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+// comment on/off as desired
+onlineSign();
+// offlineSign();

--- a/examples/node/walletSign.js
+++ b/examples/node/walletSign.js
@@ -41,6 +41,7 @@ async function onlineSign() {
       false,
     );
     const result = await zilliqa.wallet.sign(tx);
+    console.log(result);
     console.log('txn nonce: %o', result.nonce);
     console.log('txn signature: %o', result.signature);
   } catch (err) {
@@ -50,8 +51,8 @@ async function onlineSign() {
 
 /**
  *
- * wallet.sign(tx, false)
- * explicit 'false' flag implies skipping balance check
+ * wallet.sign(tx, true)
+ * explicit 'true' flag implies offline mode which skips balance checks
  *
  * example of "offline" signing, nonce is REQUIRED in the Transaction obj
  * nonce MUST BE SUPPLIED
@@ -59,13 +60,13 @@ async function onlineSign() {
  */
 async function offlineSign() {
   try {
-    console.log('Offline signing with balance check...\n');
+    console.log('Offline signing...\n');
 
-    const address = getAddressFromPrivateKey(privateKey);
-    const balance = await zilliqa.blockchain.getBalance(address);
-    console.log('current nonce is: %o', balance.result.nonce);
+    // const address = getAddressFromPrivateKey(privateKey);
+    // const balance = await zilliqa.blockchain.getBalance(address);
+    // console.log('current nonce is: %o', balance.result.nonce);
 
-    // nonce must be EXPLICITLY DEFINED when flag is 'false'
+    // nonce must be EXPLICITLY DEFINED when flag is 'true'
     const tx = zilliqa.transactions.new(
       {
         version: VERSION,
@@ -77,7 +78,8 @@ async function offlineSign() {
       },
       false,
     );
-    const result = await zilliqa.wallet.sign(tx, false);
+    const result = await zilliqa.wallet.sign(tx, true);
+    console.log(result);
     console.log('txn nonce: %o', result.nonce);
     console.log('txn signature: %o', result.signature);
   } catch (err) {
@@ -86,5 +88,5 @@ async function offlineSign() {
 }
 
 // comment on/off as desired
-onlineSign();
-// offlineSign();
+// onlineSign();
+offlineSign();

--- a/packages/zilliqa-js-account/README.md
+++ b/packages/zilliqa-js-account/README.md
@@ -237,7 +237,7 @@ See `examples/node/walletSign.js` for demonstration.
 
 - `Promise<Transaction>` - a signed transaction.
 
-### `signWith(transaction: Transaction, address: string, offlineSigning?: boolean): Promise<Transaction>`
+### `signWith(transaction: Transaction, address: string, offlineSign?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the chosen `Account`. This method is asynchronous
 as it will attempt to obtain the `nonce` from the `Provider`.

--- a/packages/zilliqa-js-account/README.md
+++ b/packages/zilliqa-js-account/README.md
@@ -227,7 +227,7 @@ There is an offline mode that can be activated manually by setting the optional 
 **Parameters**
 
 - `transaction`: `Transaction` - a `Transaction` instance.
-- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. Defaults to `false`. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
+- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. Defaults to `false` if the field is not set. If explicitly set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
 
 **Note**: In offline mode, the nonce must be explicitly set in the Transaction object.
 
@@ -247,7 +247,7 @@ There is an offline mode that can be activated manually by setting the optional 
 
 - `transaction`: `Transaction` - a `Transaction` instance.
 - `address`: `string` - the address of the `Account` to be used for signing.
-- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
+- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. Defaults to `false` if the field is not set. If explicitly set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
 
 **Note**: In offline mode, the nonce must be explicitly set in the Transaction object. 
 

--- a/packages/zilliqa-js-account/README.md
+++ b/packages/zilliqa-js-account/README.md
@@ -218,7 +218,7 @@ Sets the default account to sign with.
 
 - `void`
 
-### `sign(transaction: Transaction): Promise<Transaction>`
+### `sign(transaction: Transaction, offlineSign?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the default `Account`. This method is asynchronous
 as it will attempt to obtain the `nonce` from the `Provider`.
@@ -226,12 +226,17 @@ as it will attempt to obtain the `nonce` from the `Provider`.
 **Parameters**
 
 - `transaction`: `Transaction` - a `Transaction` instance.
+- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
+
+**Note**: In offline mode, the nonce must be explicitly set in the Transaction object.
+
+See `examples/node/walletSign.js` for demonstration.
 
 **Returns**
 
 - `Promise<Transaction>` - a signed transaction.
 
-### `signWith(transaction: Transaction, address: string): Promise<Transaction>`
+### `signWith(transaction: Transaction, address: string, offlineSigning?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the chosen `Account`. This method is asynchronous
 as it will attempt to obtain the `nonce` from the `Provider`.
@@ -240,6 +245,9 @@ as it will attempt to obtain the `nonce` from the `Provider`.
 
 - `transaction`: `Transaction` - a `Transaction` instance.
 - `address`: `string` - the address of the `Account` to be used for signing.
+- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
+
+**Note**: In offline mode, the nonce must be explicitly set in the Transaction object. 
 
 **Returns**
 

--- a/packages/zilliqa-js-account/README.md
+++ b/packages/zilliqa-js-account/README.md
@@ -221,8 +221,8 @@ Sets the default account to sign with.
 ### `sign(transaction: Transaction, offlineSign?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the default `Account`. This method is asynchronous
-as it will attempt to obtain the `nonce` from the `Provider`. Has an offline mode
-that can be activated manually by setting the optional `offlineSign` parameter.
+as it will attempt to obtain the `nonce` from the `Provider`. 
+There is an offline mode that can be activated manually by setting the optional `offlineSign` parameter.
 
 **Parameters**
 
@@ -240,8 +240,8 @@ See `examples/node/walletSign.js` for demonstration.
 ### `signWith(transaction: Transaction, address: string, offlineSigning?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the chosen `Account`. This method is asynchronous
-as it will attempt to obtain the `nonce` from the `Provider`. Has an offline mode
-that can be activated manually by setting the optional `offlineSign` parameter.
+as it will attempt to obtain the `nonce` from the `Provider`.
+There is an offline mode that can be activated manually by setting the optional `offlineSign` parameter.
 
 **Parameters**
 

--- a/packages/zilliqa-js-account/README.md
+++ b/packages/zilliqa-js-account/README.md
@@ -221,12 +221,13 @@ Sets the default account to sign with.
 ### `sign(transaction: Transaction, offlineSign?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the default `Account`. This method is asynchronous
-as it will attempt to obtain the `nonce` from the `Provider`.
+as it will attempt to obtain the `nonce` from the `Provider`. Has an offline mode
+that can be activated manually by setting the optional `offlineSign` parameter.
 
 **Parameters**
 
 - `transaction`: `Transaction` - a `Transaction` instance.
-- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
+- `offlineSign`: `boolean` (optional) - toggles offline signing on/off. Defaults to `false`. If set to `true`, offline mode is used and does not require internet connection to sign a transaction. 
 
 **Note**: In offline mode, the nonce must be explicitly set in the Transaction object.
 
@@ -239,7 +240,8 @@ See `examples/node/walletSign.js` for demonstration.
 ### `signWith(transaction: Transaction, address: string, offlineSigning?: boolean): Promise<Transaction>`
 
 Sign a `Transaction` with the chosen `Account`. This method is asynchronous
-as it will attempt to obtain the `nonce` from the `Provider`.
+as it will attempt to obtain the `nonce` from the `Provider`. Has an offline mode
+that can be activated manually by setting the optional `offlineSign` parameter.
 
 **Parameters**
 

--- a/packages/zilliqa-js-account/src/wallet.ts
+++ b/packages/zilliqa-js-account/src/wallet.ts
@@ -215,10 +215,10 @@ export class Wallet extends Signer {
    * signs an unsigned transaction with the default account.
    *
    * @param {Transaction} tx
-   * @param {boolean} checkBalance
+   * @param {boolean} offlineSign
    * @returns {Transaction}
    */
-  sign(tx: Transaction, checkBalance?: boolean): Promise<Transaction> {
+  sign(tx: Transaction, offlineSign?: boolean): Promise<Transaction> {
     if (tx.txParams && tx.txParams.pubKey) {
       // attempt to find the address
       const senderAddress = zcrypto.getAddressFromPublicKey(tx.txParams.pubKey);
@@ -229,14 +229,14 @@ export class Wallet extends Signer {
         );
       }
 
-      return this.signWith(tx, senderAddress, checkBalance);
+      return this.signWith(tx, senderAddress, offlineSign);
     }
 
     if (!this.defaultAccount) {
       throw new Error('This wallet has no default account.');
     }
 
-    return this.signWith(tx, this.defaultAccount.address, checkBalance);
+    return this.signWith(tx, this.defaultAccount.address, offlineSign);
   }
 
   /**
@@ -244,13 +244,13 @@ export class Wallet extends Signer {
    *
    * @param {Transaction} tx
    * @param {string} account
-   * @param {boolean} checkBalance
+   * @param {boolean} offlineSign
    * @returns {Transaction}
    */
   async signWith(
     tx: Transaction,
     account: string,
-    checkBalance?: boolean,
+    offlineSign?: boolean,
   ): Promise<Transaction> {
     if (!this.accounts[account]) {
       throw new Error(
@@ -266,14 +266,13 @@ export class Wallet extends Signer {
 
     try {
       if (!tx.txParams.nonce) {
-        if (checkBalance == false) {
-          // no nonce detected when skipping balance check
+        if (offlineSign) {
           throw new Error(
-            'No nonce detected in tx params when skipping balance check',
+            'No nonce detected in tx params when signing in offline mode',
           );
         }
 
-        if (typeof checkBalance === 'undefined' || checkBalance === true) {
+        if (typeof offlineSign === 'undefined' || !offlineSign) {
           // retrieve latest nonce
           const balance = await this.provider.send(
             'GetBalance',

--- a/packages/zilliqa-js-account/src/wallet.ts
+++ b/packages/zilliqa-js-account/src/wallet.ts
@@ -266,6 +266,13 @@ export class Wallet extends Signer {
 
     try {
       if (!tx.txParams.nonce) {
+        if (checkBalance == false) {
+          // no nonce detected when skipping balance check
+          throw new Error(
+            'No nonce detected in tx params when skipping balance check',
+          );
+        }
+
         if (typeof checkBalance === 'undefined' || checkBalance === true) {
           // retrieve latest nonce
           const balance = await this.provider.send(

--- a/packages/zilliqa-js-account/test/transaction.spec.ts
+++ b/packages/zilliqa-js-account/test/transaction.spec.ts
@@ -536,7 +536,7 @@ describe('Transaction', () => {
     );
   });
 
-  it('should not have error if sign checkBalance is false', async () => {
+  it('should not have error if offline sign is false', async () => {
     const responses = [
       {
         id: 1,
@@ -579,7 +579,7 @@ describe('Transaction', () => {
     expect(state.receipt).toEqual({ success: true, cumulative_gas: 1000 });
   });
 
-  it('should not have error if sign checkBalance is explicit true', async () => {
+  it('should not have error if offline sign is explicit false', async () => {
     const responses = [
       {
         id: 1,
@@ -620,7 +620,7 @@ describe('Transaction', () => {
       provider,
     );
 
-    const pending = await wallet.sign(tx, true); // explicit TRUE
+    const pending = await wallet.sign(tx, false); // explicit FALSE
     await provider.send(RPCMethod.CreateTransaction, pending.txParams);
     const confirmed = await pending.confirm('some_hash');
     const state = confirmed.txParams;

--- a/packages/zilliqa-js-account/test/wallet.spec.ts
+++ b/packages/zilliqa-js-account/test/wallet.spec.ts
@@ -207,7 +207,7 @@ describe('Wallet', () => {
     expect(() => wallet.sign(tx)).toThrow();
   });
 
-  it('should throw an error if checkBalance is false and txn does not have explicit nonce', async () => {
+  it('should throw an error if offline sign is true and txn does not have explicit nonce', async () => {
     const [wallet] = createWallet(1);
     const pubKey = (wallet.defaultAccount &&
       wallet.defaultAccount.publicKey) as string;
@@ -224,10 +224,10 @@ describe('Wallet', () => {
       provider,
     );
 
-    await expect(wallet.sign(tx)).rejects.toThrow();
+    await expect(wallet.sign(tx, true)).rejects.toThrow();
   });
 
-  it('should not have error if checkBalance is false and txn HAS explicit nonce', async () => {
+  it('should not have error if offline sign is true and txn HAS explicit nonce', async () => {
     const [wallet] = createWallet(1);
     const pubKey = (wallet.defaultAccount &&
       wallet.defaultAccount.publicKey) as string;
@@ -245,7 +245,7 @@ describe('Wallet', () => {
       provider,
     );
 
-    const signed = await wallet.sign(tx, false);
+    const signed = await wallet.sign(tx, true);
     const signature = schnorr.toSignature(signed.txParams.signature as string);
     const lgtm = schnorr.verify(
       signed.bytes,
@@ -256,7 +256,7 @@ describe('Wallet', () => {
     expect(lgtm).toBeTruthy();
   });
 
-  it('should not have error if checkBalance is explicit true and no explicit nonce', async () => {
+  it('should not have error if offline sign is explicit false and no explicit nonce', async () => {
     const [wallet] = createWallet(1);
     const pubKey = (wallet.defaultAccount &&
       wallet.defaultAccount.publicKey) as string;
@@ -284,7 +284,7 @@ describe('Wallet', () => {
       }),
     );
 
-    const signed = await wallet.sign(tx, true); // explicit TRUE
+    const signed = await wallet.sign(tx, false); // explicit FALSE
     const signature = schnorr.toSignature(signed.txParams.signature as string);
     const lgtm = schnorr.verify(
       signed.bytes,
@@ -295,7 +295,7 @@ describe('Wallet', () => {
     expect(lgtm).toBeTruthy();
   });
 
-  it('should not have error if checkBalance is explicit true and txn HAS explicit nonce', async () => {
+  it('should not have error if offline sign is explicit false and txn HAS explicit nonce', async () => {
     const [wallet] = createWallet(1);
     const pubKey = (wallet.defaultAccount &&
       wallet.defaultAccount.publicKey) as string;
@@ -313,7 +313,7 @@ describe('Wallet', () => {
       provider,
     );
 
-    const signed = await wallet.sign(tx, true); // explicit TRUE
+    const signed = await wallet.sign(tx, false); // explicit FALSE
     const signature = schnorr.toSignature(signed.txParams.signature as string);
     const lgtm = schnorr.verify(
       signed.bytes,

--- a/packages/zilliqa-js-account/test/wallet.spec.ts
+++ b/packages/zilliqa-js-account/test/wallet.spec.ts
@@ -206,4 +206,121 @@ describe('Wallet', () => {
 
     expect(() => wallet.sign(tx)).toThrow();
   });
+
+  it('should throw an error if checkBalance is false and txn does not have explicit nonce', async () => {
+    const [wallet] = createWallet(1);
+    const pubKey = (wallet.defaultAccount &&
+      wallet.defaultAccount.publicKey) as string;
+
+    const tx = new Transaction(
+      {
+        version: 0,
+        toAddr: '0x1234567890123456789012345678901234567890',
+        amount: new BN(888),
+        gasPrice: new BN(888),
+        gasLimit: Long.fromNumber(888),
+        pubKey,
+      },
+      provider,
+    );
+
+    await expect(wallet.sign(tx)).rejects.toThrow();
+  });
+
+  it('should not have error if checkBalance is false and txn HAS explicit nonce', async () => {
+    const [wallet] = createWallet(1);
+    const pubKey = (wallet.defaultAccount &&
+      wallet.defaultAccount.publicKey) as string;
+
+    const tx = new Transaction(
+      {
+        version: 1,
+        toAddr: '0x1234567890123456789012345678901234567890',
+        nonce: 1,
+        amount: new BN(0),
+        gasPrice: new BN(1000),
+        gasLimit: Long.fromNumber(1000),
+        pubKey,
+      },
+      provider,
+    );
+
+    const signed = await wallet.sign(tx, false);
+    const signature = schnorr.toSignature(signed.txParams.signature as string);
+    const lgtm = schnorr.verify(
+      signed.bytes,
+      signature,
+      Buffer.from(pubKey, 'hex'),
+    );
+
+    expect(lgtm).toBeTruthy();
+  });
+
+  it('should not have error if checkBalance is explicit true and no explicit nonce', async () => {
+    const [wallet] = createWallet(1);
+    const pubKey = (wallet.defaultAccount &&
+      wallet.defaultAccount.publicKey) as string;
+
+    const tx = new Transaction(
+      {
+        version: 1,
+        toAddr: '0x1234567890123456789012345678901234567890',
+        amount: new BN(0),
+        gasPrice: new BN(1000),
+        gasLimit: Long.fromNumber(1000),
+        pubKey,
+      },
+      provider,
+    );
+
+    fetch.once(
+      JSON.stringify({
+        id: 1,
+        jsonrpc: '2.0',
+        result: {
+          balance: '39999999000000000',
+          nonce: 1,
+        },
+      }),
+    );
+
+    const signed = await wallet.sign(tx, true); // explicit TRUE
+    const signature = schnorr.toSignature(signed.txParams.signature as string);
+    const lgtm = schnorr.verify(
+      signed.bytes,
+      signature,
+      Buffer.from(pubKey, 'hex'),
+    );
+
+    expect(lgtm).toBeTruthy();
+  });
+
+  it('should not have error if checkBalance is explicit true and txn HAS explicit nonce', async () => {
+    const [wallet] = createWallet(1);
+    const pubKey = (wallet.defaultAccount &&
+      wallet.defaultAccount.publicKey) as string;
+
+    const tx = new Transaction(
+      {
+        version: 1,
+        toAddr: '0x1234567890123456789012345678901234567890',
+        nonce: 1,
+        amount: new BN(0),
+        gasPrice: new BN(1000),
+        gasLimit: Long.fromNumber(1000),
+        pubKey,
+      },
+      provider,
+    );
+
+    const signed = await wallet.sign(tx, true); // explicit TRUE
+    const signature = schnorr.toSignature(signed.txParams.signature as string);
+    const lgtm = schnorr.verify(
+      signed.bytes,
+      signature,
+      Buffer.from(pubKey, 'hex'),
+    );
+
+    expect(lgtm).toBeTruthy();
+  });
 });


### PR DESCRIPTION
### Description
This pr is a feature request for #275 Offline Signing.

Internet connection is required for wallet signing due to the presence of `GetBalance` call which obtains the latest nonce for the Transaction object to be signed. This pr gives developers the option to bypass the `GetBalance` call by declaring a flag to toggle offline signing on/off.

The only caveat is that a nonce must be supplied by the developers should they opt for offline signing. 

### Updated Methods
```
sign(transaction: Transaction, offlineSign?: boolean)
signWith(transaction: Transaction, address: string, offlineSign?: boolean)
```
Set `offlineSign` to `true` explicitly to toggle offline signing. 

### Tests
```
yarn install
yarn bootstrap
node [project_dir]/examples/node/walletSign.js
```
