### PR TITLE
fix/nodejs-crypto-scrypt-undefined-error

### DIFF
--- a/examples/webpack/html/index.html
+++ b/examples/webpack/html/index.html
@@ -7,6 +7,7 @@
     <!-- Please generate zilliqa-min.js using yarn build:web-->>
     <script src="zilliqa.min.js"></script>
     <script src="index.js"></script>
+    <script src="load-keystore-demo.js"></script>
 </head>
 <body>
 </body>

--- a/examples/webpack/html/load-keystore-demo.js
+++ b/examples/webpack/html/load-keystore-demo.js
@@ -1,0 +1,8 @@
+async function test() {
+    const zilliqa = new Zilliqa.Zilliqa('https://dev-api.zilliqa.com');
+    const keystore = `{"address":"0x3591c6b333776a5b6c885Ada53b4462dEe8c67B6","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"1b23d4a09fa241b9cbe176fbc7d9567f"},"ciphertext":"40cce0a0b4eee4e4258341e18d880ff4b12ed25887252b90b7de4b6be86da5d5","kdf":"scrypt","kdfparams":{"salt":"4997f389a370424072967f6faeb709c238ff3cc3606a4101fc3dcbdd74b67108","n":8192,"c":262144,"r":8,"p":1,"dklen":32},"mac":"97f0677a9f0ad0c6052896e1b5ae94f86025047b9fe2617c1fce220af0db0e82"},"id":"39626239-3338-4138-b662-363663333030","version":3}`;
+    const keystoreAddress = await zilliqa.wallet.addByKeystore(keystore, "strong_password");
+    console.log("keystore loaded - address: %o", keystoreAddress);
+}
+
+  test();

--- a/examples/webpack/html/load-keystore-demo.js
+++ b/examples/webpack/html/load-keystore-demo.js
@@ -2,7 +2,10 @@ async function test() {
     const zilliqa = new Zilliqa.Zilliqa('https://dev-api.zilliqa.com');
     const keystore = `{"address":"0x3591c6b333776a5b6c885Ada53b4462dEe8c67B6","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"1b23d4a09fa241b9cbe176fbc7d9567f"},"ciphertext":"40cce0a0b4eee4e4258341e18d880ff4b12ed25887252b90b7de4b6be86da5d5","kdf":"scrypt","kdfparams":{"salt":"4997f389a370424072967f6faeb709c238ff3cc3606a4101fc3dcbdd74b67108","n":8192,"c":262144,"r":8,"p":1,"dklen":32},"mac":"97f0677a9f0ad0c6052896e1b5ae94f86025047b9fe2617c1fce220af0db0e82"},"id":"39626239-3338-4138-b662-363663333030","version":3}`;
     const keystoreAddress = await zilliqa.wallet.addByKeystore(keystore, "strong_password");
+    const exportedKeystore = await zilliqa.wallet.export("0x3591c6b333776a5b6c885Ada53b4462dEe8c67B6", "strong_password", 'scrypt');
+
     console.log("keystore loaded - address: %o", keystoreAddress);
+    console.log("exported keystore: %o", exportedKeystore);
 }
 
   test();

--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -33,6 +33,7 @@
     "hmac-drbg": "^1.0.1",
     "pbkdf2": "^3.0.16",
     "randombytes": "^2.0.6",
+    "scrypt-js": "^3.0.1",
     "scryptsy": "^2.1.0",
     "sodium-native": "^3.2.0",
     "uuid": "^3.3.2"

--- a/packages/zilliqa-js-crypto/src/keystore.ts
+++ b/packages/zilliqa-js-crypto/src/keystore.ts
@@ -18,7 +18,7 @@
 import aes from 'aes-js';
 import hashjs from 'hash.js';
 import { pbkdf2Sync } from 'pbkdf2';
-import crypto from 'crypto';
+import scrypt from 'scrypt-js';
 import uuid from 'uuid';
 
 import { bytes } from '@zilliqa-js/util';
@@ -60,7 +60,8 @@ async function getDerivedKey(
 
   if (kdf === 'scrypt') {
     const { n, r, p, dklen } = params as ScryptParams;
-    return crypto.scryptSync(key, salt, dklen, { N: n, r: r, p: p });
+    const derivedKeyInt8Array = scrypt.syncScrypt(key, salt, n, r, p, dklen);
+    return Buffer.from(derivedKeyInt8Array);
   }
 
   throw new Error('Only pbkdf2 and scrypt are supported');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8940,6 +8940,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+scrypt-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 scryptsy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"


### PR DESCRIPTION
### Problem

#### crypto.scryptSync is undefined on frontend framework
**Affected version:** `2.2.0`
**Affected symptoms:** cannot decrypt keystore files using scrypt algorithm

There was a change of `scrypt` usage from `scrypt.js` to using NodeJS's `crypto.scryptSync`. Commit:  https://github.com/Zilliqa/Zilliqa-JavaScript-Library/commit/fa9b5617474ab14d069e8ce80a795d768a1c8c94. This change was to resolve some building logging errors reported by `scrypt.js` and to take advantage of the new NodeJs `crypto` packages.

 https://github.com/Zilliqa/Zilliqa-JavaScript-Library/blob/dev/packages/zilliqa-js-crypto/src/keystore.ts#L63

However, the `crypto` package does not seem to be accessible by frontend frameworks and also our webpack bundle (`zilliqa.min.js`). Whenever users tried to execute `zilliqa.wallet.addByKeyStore` or `zilliqa.wallet.export("address", "password", 'scrypt');`, they encountered a `crypto.scryptSync` not a function error.

![image](https://user-images.githubusercontent.com/6906654/110067580-ff8acc80-7dae-11eb-826d-61dc88a79ef2.png)
![image (1)](https://user-images.githubusercontent.com/6906654/110067593-03b6ea00-7daf-11eb-81a7-9cb26a573105.png)

Unit tests are not able to catch this error, as the `crypto` package is working fine in the standard nodeJS manner, e.g. as follows:
```
const { Zilliqa } = require('@zilliqa-js/zilliqa');
const zilliqa = new Zilliqa('https://dev-api.zilliqa.com');

async function test() {
    const keystoreAddress = await zilliqa.wallet.addByKeystore(keystore, "strong_password");
    const exportedKeystore = await zilliqa.wallet.export("address", "strong_password", 'scrypt');
}

test()
```
```
node myfile.js // no errors reported
```

### Solution

This PR replaces the builti-in NodeJS `crypto.scryptSync` with a different javascript implementation; `scrypt-js`. https://github.com/ricmoo/scrypt-js. 

**How to test**
The error only affects for keystore files that are created using the scrypt algorithm. The webpack examples, `examples/webpack/html/load-keystore-demo.js` is a demonstration that adds an account by keystore and export it.

```
yarn
yarn bootstrap
yarn test
cp ./dist/zilliqa.min.js ./examples/webpack/html/

double-click /examples/webpack/html/index.html
open developer console
should see the "keystore" address and "exported keystore" output the console
```



