### PR TITLE
chore: ignore dist for formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ package.json
 .travis.yml
 *.md
 *.html
+dist


### PR DESCRIPTION
## Description
This PR makes prettier ignore dist when formatting. 

Otherwise, prettier will try to format dist which can be generated by `yarn bootstrap`.

<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

