### PR TITLE
Fix Promise resolve & HeadersInit type

### DIFF
--- a/packages/zilliqa-js-account/src/util.ts
+++ b/packages/zilliqa-js-account/src/util.ts
@@ -137,6 +137,6 @@ export const formatOutgoingTx: ReqMiddlewareFn<[TxParams]> = (req) => {
 
 export async function sleep(ms: number) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), ms);
+    setTimeout(() => resolve(undefined), ms);
   });
 }

--- a/packages/zilliqa-js-core/src/eventEmitter.ts
+++ b/packages/zilliqa-js-core/src/eventEmitter.ts
@@ -21,7 +21,7 @@ class EventEmitter<T> {
   off: (type: string, handler: mitt.Handler) => void;
   emit: (type: string, event?: any) => void;
   promise: Promise<T>;
-  resolve?: (value?: T | PromiseLike<T>) => void;
+  resolve?: (value: T | PromiseLike<T>) => void;
   reject?: (reason?: any) => void;
   then?: any;
   private handlers?: any = {};

--- a/packages/zilliqa-js-core/src/net.ts
+++ b/packages/zilliqa-js-core/src/net.ts
@@ -161,7 +161,7 @@ export const performRPC = async <R, E, D extends any[], T = RPCResponse<R, E>>(
       headers: {
         ...DEFAULT_HEADERS,
         ...((request.options && request.options.headers) || {}),
-      },
+      } as HeadersInit,
     });
 
     return response
@@ -196,7 +196,7 @@ export const performBatchRPC = async <
       headers: {
         ...DEFAULT_HEADERS,
         ...((request.options && request.options.headers) || {}),
-      },
+      } as HeadersInit,
     });
 
     return (


### PR DESCRIPTION
## Description
This PR fixes typescript errors for Promise resolve and HeadersInit.

References:
```
    /**
     * Creates a new Promise.
     * @param executor A callback used to initialize the promise. This callback is passed two arguments:
     * a resolve callback used to resolve the promise with a value or the result of another promise,
     * and a reject callback used to reject the promise with a provided reason or error.
     */
    new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;

```

```
    headers?: HeadersInit;
    /**
     * A cryptographic hash of the resource to be fetched by request. Sets request's integrity.
     */
```
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

