### PR TITLE
build: add tslib as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "ts-jest": "^23.1.3",
     "ts-loader": "8.0.4",
     "ts-node": "^7.0.1",
+    "tslib": "^2.3.0",
     "typescript": "^3.2",
     "typescript-json-schema": "^0.32.0",
     "webpack": "^4.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10690,6 +10690,11 @@ tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"


### PR DESCRIPTION
## Description

This PR adds `tslib` as dev dependency.

## Background
In near future, we should upgrade typescript `3.2` -> `4.3` to leverage new features in v4.

However, with typescript 4.3.5, `yarn bootstrap` throws the following error.

```
packages/zilliqa-js-core/src/decorators/sign.ts:45:42 - error TS2343: This syntax requires an imported helper named '__spreadArray' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.

45       return original.call(this, signed, ...args);
                                            ~~~~~~~
```

<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

