### PR TITLE
Make getTransactionStatus argument format somewhat intuitive

### DIFF
--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -525,7 +525,7 @@ export class Blockchain implements ZilliqaModule {
     try {
       const response = await this.provider.send<TransactionObj>(
         RPCMethod.GetTransaction,
-        txHash,
+        txHash.replace('0x', ''),
       );
 
       if (response.error) {

--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -552,7 +552,7 @@ export class Blockchain implements ZilliqaModule {
     try {
       const response = await this.provider.send<TransactionStatusObj>(
         RPCMethod.GetTransactionStatus,
-        txHash,
+        txHash.replace('0x', ''),
       );
       if (response.error) {
         return Promise.reject(response.error);


### PR DESCRIPTION
Zilliqa  JSON RPC is inconsistent. No one would ever guess that `getTransactionStatus` method suppose to accept `txHash` argument without `0x` prefix. Made it indifferent to the prefix.