### PR TITLE
build: remove @trust/webcrypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@babel/preset-env": "7.0.0-beta.54",
     "@babel/preset-typescript": "^7.0.0-beta.56",
     "@babel/runtime": "^7.0.0-beta.56",
-    "@trust/webcrypto": "^0.9.2",
     "@types/bn.js": "^4.11.3",
     "@types/camelcase": "^4.1.0",
     "@types/fancy-log": "^1.3.0",


### PR DESCRIPTION
## Description
This PR removes `@trust/webcrypto` from package.json which is an unused dependency and should've been removed from https://github.com/Zilliqa/Zilliqa-JavaScript-Library/commit/b2204bcd5db68a8ac7d010afb0fb9faa1be49a8f
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
