### PR TITLE
fix: whitelist production files

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,13 +64,5 @@
     "webpack": "^4.20.2",
     "webpack-command": "^0.4.1"
   },
-  "files": [
-    "packages/**/dist",
-    "packages/**/node_modules",
-    "packages/**/package.json",
-    "packages/**/LICENSEs",
-    "packages/**/CHANGELOG.md",
-    "packages/**/README.md"
-  ],
   "dependencies": {}
 }

--- a/packages/zilliqa-js-account/package.json
+++ b/packages/zilliqa-js-account/package.json
@@ -34,6 +34,14 @@
     "bip39": "^2.5.0",
     "hdkey": "^1.1.0"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa-js-blockchain/package.json
+++ b/packages/zilliqa-js-blockchain/package.json
@@ -32,6 +32,14 @@
     "@zilliqa-js/util": "3.0.0",
     "utility-types": "^3.4.1"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa-js-contract/package.json
+++ b/packages/zilliqa-js-contract/package.json
@@ -33,6 +33,14 @@
     "hash.js": "^1.1.5",
     "utility-types": "^2.1.0"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa-js-core/package.json
+++ b/packages/zilliqa-js-core/package.json
@@ -30,6 +30,14 @@
     "cross-fetch": "2.2.5",
     "mitt": "^1.1.3"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -37,5 +37,13 @@
     "scryptsy": "^2.1.0",
     "sodium-native": "^3.2.1",
     "uuid": "^3.3.2"
-  }
+  },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ]
 }

--- a/packages/zilliqa-js-proto/package.json
+++ b/packages/zilliqa-js-proto/package.json
@@ -30,6 +30,14 @@
   "dependencies": {
     "protobufjs": "^6.8.8"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa-js-subscriptions/package.json
+++ b/packages/zilliqa-js-subscriptions/package.json
@@ -29,5 +29,13 @@
     "@zilliqa-js/core": "3.0.0",
     "mock-socket": "^9.0.2",
     "websocket": "^1.0.28"
-  }
+  },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ]
 }

--- a/packages/zilliqa-js-util/package.json
+++ b/packages/zilliqa-js-util/package.json
@@ -30,6 +30,14 @@
     "bn.js": "^4.11.8",
     "long": "^4.0.0"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }

--- a/packages/zilliqa/package.json
+++ b/packages/zilliqa/package.json
@@ -30,6 +30,14 @@
     "@zilliqa-js/subscriptions": "3.0.0",
     "@zilliqa-js/util": "3.0.0"
   },
+  "files": [
+    "packages/**/dist",
+    "packages/**/node_modules",
+    "packages/**/package.json",
+    "packages/**/LICENSE",
+    "packages/**/CHANGELOG.md",
+    "packages/**/README.md"
+  ],
   "engines": {
     "node": ">=12.0.0 <15"
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR fixes https://github.com/Zilliqa/Zilliqa-JavaScript-Library/issues/331.


## Motivation and Context
By simulating a publish with Verdaccio, I found out that https://github.com/Zilliqa/Zilliqa-JavaScript-Library/pull/332 doesn't work with a actual publish with lerna.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Simulated a publish with a local npm proxy registry using Verdaccio.
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):
<img width="1301" alt="Screen Shot 2021-08-25 at 12 10 33 PM" src="https://user-images.githubusercontent.com/86328181/130723883-124cdb04-7c71-4309-911c-06733ab33602.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
