### PR TITLE
feat(blockchain): remove contract dep

### DIFF
--- a/packages/zilliqa-js-blockchain/src/chain.ts
+++ b/packages/zilliqa-js-blockchain/src/chain.ts
@@ -18,7 +18,6 @@
 import { Transaction, util, Wallet } from '@zilliqa-js/account';
 import { fromBech32Address } from '@zilliqa-js/crypto';
 import { validation } from '@zilliqa-js/util';
-import { ContractObj, Value } from '@zilliqa-js/contract';
 import {
   BlockchainInfo,
   BlockList,
@@ -471,7 +470,7 @@ export class Blockchain implements ZilliqaModule {
 
   // Returns the initialization (immutable) parameters of
   // a given smart contract, represented in a JSON format.
-  getSmartContractInit(addr: string): Promise<RPCResponse<Value[], string>> {
+  getSmartContractInit(addr: string): Promise<RPCResponse<any, string>> {
     const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContractInit,
@@ -512,7 +511,7 @@ export class Blockchain implements ZilliqaModule {
     return this.provider.sendBatch(RPCMethod.GetSmartContractSubState, reqs);
   }
 
-  getSmartContracts(addr: string): Promise<RPCResponse<ContractObj[], string>> {
+  getSmartContracts(addr: string): Promise<RPCResponse<any, string>> {
     const address = validation.isBech32(addr) ? fromBech32Address(addr) : addr;
     return this.provider.send(
       RPCMethod.GetSmartContracts,

--- a/packages/zilliqa-js-blockchain/tsconfig.json
+++ b/packages/zilliqa-js-blockchain/tsconfig.json
@@ -7,7 +7,7 @@
   "include": ["src", "../../typings/**/*.d.ts"],
   "references": [
     { "path": "../zilliqa-js-account" },
-    { "path": "../zilliqa-js-contract" },
+    { "path": "../zilliqa-js-crypto" },
     { "path": "../zilliqa-js-core" }
   ]
 }


### PR DESCRIPTION
## Description
This PR 
- removes `contract` dep from `blockchain` by using `any` type instead and closes the #397.
- fixes the `zilliqa-js-crypto` ref in the tsconfig.
- solves subproblems of what https://github.com/Zilliqa/Zilliqa-JavaScript-Library/pull/379 tried to solve.

References:
- https://github.com/Zilliqa/Zilliqa/pull/2728
- https://github.com/Zilliqa/dev-portal/pull/204
- https://github.com/Zilliqa/Zilliqa-JavaScript-Library/pull/379

| Current Dependency Graph (v3.1.0) |
|:-:|
|![zil-js-dep-graph 001](https://user-images.githubusercontent.com/86328181/134621805-fb697d4d-b2f2-4461-9409-a098db1c8184.png)|

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
