### PR TITLE
Add type declaration for signature and change require to import

### DIFF
--- a/packages/zilliqa-js-crypto/src/index.ts
+++ b/packages/zilliqa-js-crypto/src/index.ts
@@ -16,30 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import * as schnorr from './schnorr';
-
-// This is a workaround. We need to improve it.
-const Signature = require('elliptic/lib/elliptic/ec/signature');
-// Q. Why do we use require() here?
-// A. At the moment, Signature() in 'elliptic' is can only be imported
-// from 'elliptic/lib/elliptic/ec/signature'. If we use ES6 import syntax,
-// TS will try to generate d.ts from 'elliptic/lib/elliptic/ec/signature'
-// causing an error with 'Could not find a declaration file for module ...' message.
-// Therefore, we use require() here.
-//
-// Q. Why don't we use `ec.Signature` type for 'Signature()'?
-// A. `Signature()` is a function while @types/elliptic defines it as following
-//
-// class Signature {
-//   r: BN;
-//   s: BN;
-//   recoveryParam: number | null;
-//   constructor(options: SignatureInput, enc?: string);
-//   toDER(enc?: string | null): any; // ?
-// }
-//
-// With the above `ec.Signature` type, `new Signature()` will throw an error
-// since it doesn't have constructor().
-// Therefore, we keep the type of Signature() as any.
+import Signature from 'elliptic/lib/elliptic/ec/signature.js'
 
 /**
  * sign

--- a/typings/signature.d.ts
+++ b/typings/signature.d.ts
@@ -1,0 +1,10 @@
+declare module 'elliptic/lib/elliptic/ec/signature.js' {
+  class Signature {
+    r: any;
+    s: any;
+    recoveryParam: any;
+    toDER: any;
+    constructor({ r, s }: { r: any; s: any; [key: string]: any });
+  }
+  export = Signature;
+}


### PR DESCRIPTION
Fixes #422 

This is an ugly hack but passes the tests in the repo. This change also fixed the issue i was having with vite building. I don't think this is any different from just having `Signature` as implicit any but the typings can definetly be worked on.