### PR TITLE
chore(eslint): no-require-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     'no-unreachable': 2,
+    '@typescript-eslint/no-require-imports': 2,
     eqeqeq: 2,
     // The following rules are added to minimize changeset
     // Reduce the following rules gradually

--- a/packages/zilliqa-js-crypto/src/index.ts
+++ b/packages/zilliqa-js-crypto/src/index.ts
@@ -18,6 +18,7 @@
 import * as schnorr from './schnorr';
 
 // This is a workaround. We need to improve it.
+// eslint-disable-next-line
 const Signature = require('elliptic/lib/elliptic/ec/signature');
 // Q. Why do we use require() here?
 // A. At the moment, Signature() in 'elliptic' is can only be imported

--- a/packages/zilliqa-js-crypto/src/random.ts
+++ b/packages/zilliqa-js-crypto/src/random.ts
@@ -63,6 +63,7 @@ export const randomBytes = (bytes: number) => {
     // For node enviroment, use sodium-native
     // https://paragonie.com/blog/2016/05/how-generate-secure-random-numbers-in-various-programming-languages#nodejs-csprng
 
+    // eslint-disable-next-line
     const sodium = require('sodium-native');
     sodium.randombytes_buf(b);
   } else {


### PR DESCRIPTION
## Description
This PR prefers the newer ES6-style imports over require() by adding [no-require-imports](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-require-imports.md) rule and also prevents the issues like #422.

Also, to pass the CI this PR disables lint for the two existing require imports until all require imports are removed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
