### PR TITLE
fix: uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/fancy-log": "^1.3.0",
     "@types/jest": "27.0.1",
     "@types/node": "^16.6.1",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "8.3.1",
     "@types/webpack": "^4.4.17",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",

--- a/packages/zilliqa-js-crypto/src/keystore.ts
+++ b/packages/zilliqa-js-crypto/src/keystore.ts
@@ -19,7 +19,7 @@ import aes from 'aes-js';
 import hashjs from 'hash.js';
 import { pbkdf2Sync } from 'pbkdf2';
 import scrypt from 'scrypt-js';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import { bytes } from '@zilliqa-js/util';
 
@@ -137,7 +137,7 @@ export const encryptPrivateKey = async (
         )
         .digest('hex'),
     },
-    id: uuid.v4({ random: bytes.hexToIntArray(randomBytes(16)) }),
+    id: uuidv4({ random: bytes.hexToIntArray(randomBytes(16)) }),
     version: 3,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,12 +1869,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^3.4.4":
-  version "3.4.5"
-  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
-  integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@8.3.1":
+  version "8.3.1"
+  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@types/webpack-sources@*":
   version "0.1.5"


### PR DESCRIPTION
## Description

This PR uses `import { v4 as uuidv4 } from 'uuid';`
Also, it updates `@types/uuid` to v8.3.1

> const uuid = require('uuid'); // <== REMOVED!
> This usage pattern was already discouraged in uuid@3.x and has been removed in uuid@7.x.



Reference:
- https://www.npmjs.com/package/uuid#default-export-removed
- https://stackoverflow.com/questions/60830848/attempted-import-error-uuid-does-not-contain-a-default-export-imported-as-u
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
