### PR TITLE
fix: sodium-native

### DIFF
--- a/packages/zilliqa-js-crypto/package.json
+++ b/packages/zilliqa-js-crypto/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@types/uuid": "8.3.1",
-    "@types/sodium-native": "2.3.5",
     "@types/elliptic": "^6.4.13",
     "@zilliqa-js/util": "^3.3.2",
     "aes-js": "^3.1.1",

--- a/packages/zilliqa-js-crypto/src/random.ts
+++ b/packages/zilliqa-js-crypto/src/random.ts
@@ -15,8 +15,6 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import sodium from 'sodium-native';
-
 /**
  * randomBytes
  *
@@ -69,6 +67,15 @@ export const randomBytes = (bytes: number) => {
     // References:
     // - https://paragonie.com/blog/2016/05/how-generate-secure-random-numbers-in-various-programming-languages#nodejs-csprng
     // - https://github.com/nodejs/node/issues/5798
+    //
+    // This logic should run only in node env. Otherwise, it will throw an error 'require is not defined'.
+    //
+    // Consider using createRequire when typescipt 4.5 is available.
+    // https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta
+    // https://nodejs.org/api/module.html#modulecreaterequirefilename
+    //
+    // eslint-disable-next-line
+    const sodium = require('sodium-native');
     sodium.randombytes_buf(b);
   } else {
     throw new Error('No secure random number generator available');

--- a/packages/zilliqa-js-crypto/test/random.node.spec.ts
+++ b/packages/zilliqa-js-crypto/test/random.node.spec.ts
@@ -21,18 +21,6 @@
 
 import { randomBytes } from '../src/random';
 
-const mockFn = jest.fn();
-
-jest.mock('sodium-native');
-
-// eslint-disable-next-line
-const sodium = require('sodium-native');
-
-sodium.randombytes_buf.mockImplementation(() => {
-  mockFn();
-  return global.Buffer.allocUnsafe(16).fill(0);
-});
-
 beforeEach(() => {
   jest.resetModules();
 });
@@ -45,6 +33,11 @@ describe('random', () => {
       value: {
         allocUnsafe: mockAllocUnsafe,
       },
+    });
+
+    const mockFn = jest.fn();
+    jest.doMock('sodium-native', () => {
+      return { randombytes_buf: mockFn };
     });
 
     const want = '00000000000000000000000000000000';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,13 +1840,6 @@
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
-"@types/sodium-native@2.3.5":
-  version "2.3.5"
-  resolved "https://registry.npmjs.org/@types/sodium-native/-/sodium-native-2.3.5.tgz#5d2681e7b6b67bcbdc63cfb133e303ec9e942e43"
-  integrity sha512-a3DAIpW8+36XAY8aIR36JBQQsfOabxHuJwx11DL/PTvnbwEWPAXW66b8QbMi0r2vUnkOfREsketxdvjBmQxqDQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"


### PR DESCRIPTION
## Description
This PR reverts #428 with modifications. 
If we use ES6 import syntax for sodium-native, in browsers it will throw an error `require is not defined`.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
